### PR TITLE
feat: add forget memory support across interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,25 @@ recall({ query: "coding preferences", limit: 5 })
 - `category` (optional): Filter by category
 - `min_strength` (optional): Minimum strength threshold (0.0-1.0)
 
+### `forget`
+
+Delete a stored memory by ID.
+
+```
+forget({ id: "memory-uuid" })
+```
+
+**Parameters:**
+- `id` (required): Memory ID to delete
+
+**Returns:**
+- `id`: Requested memory ID
+- `deleted`: `true` if a memory was deleted, `false` if it did not exist
+
+When users ask to forget by phrase (for example, "forget the memory about API keys"),
+the assistant should first call `recall` to resolve candidates, then call `forget`
+with the selected memory ID.
+
 ## Configuration
 
 Database location: `~/.local/share/engram/engram.db`

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@
  *   engram search <query>  Search memories by keyword
  *   engram metrics         Show usage metrics
  *   engram show <id>       Show a specific memory
+ *   engram forget <id>     Delete a specific memory
  *
  *   engram serve           Start HTTP server (foreground)
  *   engram start           Start HTTP server as daemon
@@ -28,6 +29,7 @@ import {
   stopDaemon,
 } from "./daemon";
 import {
+  deleteMemoryById,
   getMemoryById,
   getMetricsSummary,
   getRecentMemories,
@@ -46,6 +48,7 @@ Usage:
   engram search <query>  Search memories by keyword
   engram metrics         Show usage metrics
   engram show <id>       Show a specific memory
+  engram forget <id>     Delete a specific memory
 
   engram serve           Start HTTP server (foreground)
   engram start           Start HTTP server as daemon
@@ -233,6 +236,28 @@ function cmdShow(id: string | undefined, json: boolean): void {
   console.log();
 }
 
+function cmdForget(id: string | undefined, json: boolean): void {
+  if (!id) {
+    console.error("Error: memory ID required");
+    console.error("Usage: engram forget <id>");
+    process.exit(1);
+  }
+
+  const deleted = deleteMemoryById(id);
+
+  if (json) {
+    console.log(JSON.stringify({ id, deleted }, null, 2));
+    process.exit(deleted ? 0 : 1);
+  }
+
+  if (!deleted) {
+    console.error(`Error: memory not found: ${id}`);
+    process.exit(1);
+  }
+
+  console.log(`Deleted memory: ${id}`);
+}
+
 function cmdServe(): void {
   console.log("Starting Engram HTTP server...");
   const server = startHttpServer();
@@ -347,6 +372,9 @@ async function main(): Promise<void> {
       break;
     case "show":
       cmdShow(args[0], json);
+      break;
+    case "forget":
+      cmdForget(args[0], json);
       break;
     case "help":
       console.log(HELP);

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -142,6 +142,13 @@ export function updateMemoryAccess(id: string): void {
   stmt.run({ $id: id });
 }
 
+export function deleteMemoryById(id: string): boolean {
+  const database = getDatabase();
+  const stmt = database.prepare("DELETE FROM memories WHERE id = $id");
+  const result = stmt.run({ $id: id });
+  return result.changes > 0;
+}
+
 export function countMemories(): number {
   const database = getDatabase();
   const stmt = database.prepare("SELECT COUNT(*) as count FROM memories");
@@ -179,7 +186,7 @@ export function searchMemories(query: string, limit: number): SearchResult[] {
 
 export interface MetricEvent {
   session_id?: string;
-  event: "remember" | "recall";
+  event: "remember" | "recall" | "forget";
   memory_id?: string;
   query?: string;
   result_count?: number;

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -50,7 +50,7 @@ CREATE TABLE IF NOT EXISTS metrics (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     timestamp TEXT DEFAULT (datetime('now')),
     session_id TEXT,
-    event TEXT NOT NULL,          -- 'remember', 'recall'
+    event TEXT NOT NULL,          -- 'remember', 'recall', 'forget'
     memory_id TEXT,               -- for remember events
     query TEXT,                   -- for recall events
     result_count INTEGER,         -- for recall events

--- a/src/http.ts
+++ b/src/http.ts
@@ -4,6 +4,7 @@
  * Provides REST API for memory operations:
  * - POST /remember - Store a memory
  * - POST /recall - Retrieve memories
+ * - POST /forget - Delete a memory by ID
  * - GET /health - Health check
  *
  * Used by OpenCode plugin for silent memory extraction.
@@ -11,6 +12,7 @@
 
 import { getConfig } from "./config";
 import { initDatabase } from "./db";
+import { type ForgetInput, forget } from "./tools/forget";
 import { type RecallInput, recall } from "./tools/recall";
 import { type RememberInput, remember } from "./tools/remember";
 
@@ -101,6 +103,21 @@ async function handleRequest(req: Request): Promise<Response> {
       }
 
       const result = await recall(body);
+      return Response.json(result, { headers });
+    }
+
+    // Forget endpoint
+    if (path === "/forget" && method === "POST") {
+      const body = (await req.json()) as ForgetInput;
+
+      if (!body.id) {
+        return Response.json(
+          { error: "id is required" },
+          { status: 400, headers },
+        );
+      }
+
+      const result = await forget(body);
       return Response.json(result, { headers });
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import {
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { initDatabase } from "./db";
+import { type ForgetInput, forget } from "./tools/forget";
 import { type RecallInput, recall } from "./tools/recall";
 import { type RememberInput, remember } from "./tools/remember";
 
@@ -86,6 +87,25 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           required: ["query"],
         },
       },
+      {
+        name: "forget",
+        description: "Delete a stored memory by ID.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            id: {
+              type: "string",
+              description: "Memory ID to delete",
+            },
+            session_id: {
+              type: "string",
+              description:
+                "Optional session identifier from the calling harness (e.g., OpenCode session ID)",
+            },
+          },
+          required: ["id"],
+        },
+      },
     ],
   };
 });
@@ -117,6 +137,22 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         throw new Error("query is required");
       }
       const result = await recall(input);
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    }
+
+    case "forget": {
+      const input = args as unknown as ForgetInput;
+      if (!input.id) {
+        throw new Error("id is required");
+      }
+      const result = await forget(input);
       return {
         content: [
           {

--- a/src/tools/forget.ts
+++ b/src/tools/forget.ts
@@ -1,0 +1,26 @@
+import { deleteMemoryById, logMetric } from "../db";
+
+export interface ForgetInput {
+  id: string;
+  session_id?: string;
+}
+
+export interface ForgetOutput {
+  id: string;
+  deleted: boolean;
+}
+
+export async function forget(input: ForgetInput): Promise<ForgetOutput> {
+  const deleted = deleteMemoryById(input.id);
+
+  logMetric({
+    session_id: input.session_id,
+    event: "forget",
+    memory_id: input.id,
+  });
+
+  return {
+    id: input.id,
+    deleted,
+  };
+}

--- a/test/db.test.ts
+++ b/test/db.test.ts
@@ -3,10 +3,12 @@ import {
   closeDatabase,
   countMemories,
   createMemory,
+  deleteMemoryById,
   getAllMemories,
   getMemoryById,
   initDatabase,
   resetDatabase,
+  searchMemories,
   updateMemoryAccess,
 } from "../src/db";
 
@@ -89,5 +91,33 @@ describe("Database", () => {
 
     createMemory({ id: "m2", content: "Memory 2" });
     expect(countMemories()).toBe(2);
+  });
+
+  test("deletes an existing memory", () => {
+    createMemory({ id: "delete-me", content: "Temporary memory" });
+
+    const deleted = deleteMemoryById("delete-me");
+
+    expect(deleted).toBe(true);
+    expect(getMemoryById("delete-me")).toBeNull();
+    expect(countMemories()).toBe(0);
+  });
+
+  test("delete is idempotent for missing memory", () => {
+    const deleted = deleteMemoryById("missing-memory");
+
+    expect(deleted).toBe(false);
+  });
+
+  test("deleting a memory removes it from search", () => {
+    createMemory({ id: "search-1", content: "Project budget note" });
+
+    const beforeDelete = searchMemories("budget", 10);
+    expect(beforeDelete.map((m) => m.id)).toContain("search-1");
+
+    deleteMemoryById("search-1");
+
+    const afterDelete = searchMemories("budget", 10);
+    expect(afterDelete.map((m) => m.id)).not.toContain("search-1");
   });
 });

--- a/test/forget.test.ts
+++ b/test/forget.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  closeDatabase,
+  getMemoryById,
+  getMetricsSummary,
+  initDatabase,
+  resetDatabase,
+} from "../src/db";
+import { resetEmbedder } from "../src/embedding";
+import { forget } from "../src/tools/forget";
+import { remember } from "../src/tools/remember";
+
+describe("forget tool", () => {
+  beforeEach(() => {
+    resetDatabase();
+    resetEmbedder();
+    initDatabase(":memory:");
+  });
+
+  afterEach(() => {
+    closeDatabase();
+  });
+
+  test("deletes a stored memory", async () => {
+    const memory = await remember({ content: "Disposable memory" });
+
+    const result = await forget({ id: memory.id });
+
+    expect(result).toEqual({ id: memory.id, deleted: true });
+    expect(getMemoryById(memory.id)).toBeNull();
+  });
+
+  test("returns deleted false when memory does not exist", async () => {
+    const result = await forget({ id: "does-not-exist" });
+
+    expect(result).toEqual({ id: "does-not-exist", deleted: false });
+  });
+
+  test("logs forget metric event", async () => {
+    const memory = await remember({
+      content: "Memory to forget",
+      session_id: "session-forget",
+    });
+
+    await forget({ id: memory.id, session_id: "session-forget" });
+
+    const summary = getMetricsSummary("session-forget");
+    expect(summary.total_remembers).toBe(1);
+    expect(summary.total_recalls).toBe(0);
+  });
+});

--- a/test/recall.test.ts
+++ b/test/recall.test.ts
@@ -6,6 +6,7 @@ import {
   resetDatabase,
 } from "../src/db";
 import { resetEmbedder } from "../src/embedding";
+import { forget } from "../src/tools/forget";
 import { recall } from "../src/tools/recall";
 import { remember } from "../src/tools/remember";
 
@@ -106,6 +107,19 @@ describe("recall tool", () => {
     await remember({ content: "Test memory" });
     const result = await recall({ query: "   " });
     expect(result.fallback_mode).toBe(true);
+  });
+
+  test("does not return forgotten memories", async () => {
+    const keep = await remember({ content: "Keep this memory" });
+    const remove = await remember({ content: "Forget this memory" });
+
+    await forget({ id: remove.id });
+
+    const result = await recall({ query: "memory" });
+    const ids = result.memories.map((m) => m.id);
+
+    expect(ids).toContain(keep.id);
+    expect(ids).not.toContain(remove.id);
   });
 
   // Semantic search behavior tests


### PR DESCRIPTION
## Summary
- add a new `forget` tool/service for hard-deleting memories by id with idempotent `{ id, deleted }` responses
- expose forget across MCP (`forget` tool), HTTP (`POST /forget`), and CLI (`engram forget <id>`), and document usage in the README
- expand tests to cover deletion semantics, search/recall exclusion after deletion, and forget tool behavior

## Validation
- bun run validate