### PR TITLE
feat: Add one-command AWS EC2 deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,9 @@ Thumbs.db
 # Environment
 .env
 .env.local
+
+# Compiled binaries
+engram-server
+
+# SSH keys
+*.pem

--- a/README.md
+++ b/README.md
@@ -4,12 +4,53 @@ Persistent memory for AI agents. An MCP server that gives your AI assistant long
 
 ## Quick Start
 
+### Option 1: Local (Recommended for personal use)
+
 ```bash
-# Clone and install
-git clone <repo>
+git clone https://github.com/shetty4l/engram.git
 cd engram
 ./scripts/install.sh
 ```
+
+Add to your MCP client config:
+
+```json
+{
+  "engram": {
+    "command": "bun",
+    "args": ["run", "/path/to/engram/src/index.ts"]
+  }
+}
+```
+
+### Option 2: AWS EC2 (Always-on, cross-device)
+
+Deploy to your AWS account with one command. Requires AWS CLI configured.
+
+```bash
+git clone https://github.com/shetty4l/engram.git
+cd engram
+./scripts/deploy-aws.sh
+```
+
+This will:
+- Launch a t3.small EC2 instance with Amazon Linux 2023
+- Install Bun and Engram automatically
+- Configure SSM for secure access (no public ports)
+- Output the MCP config to add to your client
+
+**Requirements:**
+- AWS CLI installed and configured (`aws configure` or `aws sso login`)
+- IAM permissions: EC2, IAM, SSM
+
+**Cost:** ~$15-20/month (t3.small + 10GB EBS). Stop the instance when not in use to save costs.
+
+**Cleanup:**
+```bash
+./scripts/destroy-aws.sh
+```
+
+The script creates `~/.engram/` with your key and instance info.
 
 ## OpenCode Setup
 
@@ -77,19 +118,6 @@ engram status
   - `engram status`
   - `engram restart`
   - `curl http://127.0.0.1:7749/health`
-
-Add to your MCP client config (e.g., OpenCode, Claude Desktop):
-
-```json
-{
-  "mcpServers": {
-    "engram": {
-      "command": "bun",
-      "args": ["run", "/path/to/engram/src/index.ts"]
-    }
-  }
-}
-```
 
 ## Tools
 

--- a/scripts/deploy-aws.sh
+++ b/scripts/deploy-aws.sh
@@ -1,0 +1,261 @@
+#!/bin/bash
+set -e
+
+# Engram AWS EC2 Deployment Script
+# Deploys Engram to your AWS account with SSM-based access (no public ports)
+
+INSTANCE_TYPE="${INSTANCE_TYPE:-t3.small}"
+ENGRAM_DIR="${ENGRAM_DIR:-$HOME/.engram}"
+KEY_NAME="engram-server-$(date +%s)"
+
+# Track created resources for cleanup on failure
+CREATED_KEY=""
+CREATED_INSTANCE=""
+
+cleanup_on_failure() {
+    echo ""
+    echo "⚠ Deployment failed. Cleaning up..."
+    
+    if [ -n "$CREATED_INSTANCE" ]; then
+        echo "  Terminating instance $CREATED_INSTANCE..."
+        aws ec2 terminate-instances --instance-ids "$CREATED_INSTANCE" &>/dev/null || true
+    fi
+    
+    if [ -n "$CREATED_KEY" ]; then
+        echo "  Deleting key pair $CREATED_KEY..."
+        aws ec2 delete-key-pair --key-name "$CREATED_KEY" &>/dev/null || true
+        rm -f "$ENGRAM_DIR/$CREATED_KEY.pem" 2>/dev/null || true
+    fi
+    
+    echo "  Cleanup complete."
+    exit 1
+}
+
+trap cleanup_on_failure ERR
+
+echo "=== Engram AWS Deployment ==="
+echo ""
+
+# Pre-flight checks
+echo "Checking prerequisites..."
+
+if ! command -v aws &> /dev/null; then
+    echo "❌ AWS CLI not found. Install: https://aws.amazon.com/cli/"
+    exit 1
+fi
+
+if ! aws sts get-caller-identity &> /dev/null; then
+    echo "❌ AWS credentials not configured. Run: aws configure (or aws sso login)"
+    exit 1
+fi
+
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+REGION=$(aws configure get region || echo "us-east-1")
+echo "✓ AWS CLI configured (Account: $ACCOUNT_ID, Region: $REGION)"
+
+# Get latest Amazon Linux 2023 AMI
+echo ""
+echo "Finding latest Amazon Linux 2023 AMI..."
+AMI_ID=$(aws ec2 describe-images \
+    --owners amazon \
+    --filters "Name=name,Values=al2023-ami-2023*-x86_64" "Name=state,Values=available" \
+    --query "Images | sort_by(@, &CreationDate) | [-1].ImageId" \
+    --output text)
+
+if [ "$AMI_ID" == "None" ] || [ -z "$AMI_ID" ]; then
+    echo "❌ Could not find Amazon Linux 2023 AMI"
+    exit 1
+fi
+echo "✓ AMI: $AMI_ID"
+
+# Create key pair
+echo ""
+echo "Creating EC2 key pair..."
+mkdir -p "$ENGRAM_DIR"
+aws ec2 create-key-pair \
+    --key-name "$KEY_NAME" \
+    --query 'KeyMaterial' \
+    --output text > "$ENGRAM_DIR/$KEY_NAME.pem"
+chmod 600 "$ENGRAM_DIR/$KEY_NAME.pem"
+CREATED_KEY="$KEY_NAME"
+echo "✓ Key saved: $ENGRAM_DIR/$KEY_NAME.pem"
+
+# Create IAM role for SSM (if doesn't exist)
+echo ""
+echo "Setting up IAM role for SSM..."
+ROLE_NAME="engram-ec2-ssm-role"
+INSTANCE_PROFILE_NAME="engram-ec2-ssm-profile"
+
+if ! aws iam get-role --role-name "$ROLE_NAME" &> /dev/null; then
+    aws iam create-role \
+        --role-name "$ROLE_NAME" \
+        --assume-role-policy-document '{
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Principal": {"Service": "ec2.amazonaws.com"},
+                "Action": "sts:AssumeRole"
+            }]
+        }' > /dev/null
+    
+    aws iam attach-role-policy \
+        --role-name "$ROLE_NAME" \
+        --policy-arn arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+    
+    echo "✓ Created IAM role: $ROLE_NAME"
+else
+    echo "✓ IAM role exists: $ROLE_NAME"
+fi
+
+if ! aws iam get-instance-profile --instance-profile-name "$INSTANCE_PROFILE_NAME" &> /dev/null; then
+    aws iam create-instance-profile --instance-profile-name "$INSTANCE_PROFILE_NAME" > /dev/null
+    aws iam add-role-to-instance-profile \
+        --instance-profile-name "$INSTANCE_PROFILE_NAME" \
+        --role-name "$ROLE_NAME"
+    echo "✓ Created instance profile: $INSTANCE_PROFILE_NAME"
+    echo "  Waiting 10s for IAM propagation..."
+    sleep 10
+else
+    echo "✓ Instance profile exists: $INSTANCE_PROFILE_NAME"
+fi
+
+# User data script to install Bun and Engram
+USER_DATA=$(cat << 'USERDATA'
+#!/bin/bash
+set -e
+
+# Install git (not included in AL2023 minimal)
+dnf install -y git
+
+# Install Bun and Engram as ec2-user (sudo -i sets HOME correctly)
+sudo -i -u ec2-user bash << 'EOF'
+set -e
+curl -fsSL https://bun.sh/install | bash
+export PATH="$HOME/.bun/bin:$PATH"
+
+# Clone and install Engram
+cd ~
+git clone https://github.com/shetty4l/engram.git
+~/.bun/bin/bun install --cwd ~/engram
+EOF
+
+# Create data directory (needs root)
+mkdir -p /data/engram
+chown ec2-user:ec2-user /data/engram
+
+# Signal completion
+touch /home/ec2-user/.engram-ready
+USERDATA
+)
+
+# Launch EC2 instance
+echo ""
+echo "Launching EC2 instance ($INSTANCE_TYPE)..."
+INSTANCE_ID=$(aws ec2 run-instances \
+    --image-id "$AMI_ID" \
+    --instance-type "$INSTANCE_TYPE" \
+    --key-name "$KEY_NAME" \
+    --iam-instance-profile Name="$INSTANCE_PROFILE_NAME" \
+    --user-data "$USER_DATA" \
+    --block-device-mappings '[{"DeviceName":"/dev/xvda","Ebs":{"VolumeSize":10,"VolumeType":"gp3"}}]' \
+    --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=engram-server}]" \
+    --query 'Instances[0].InstanceId' \
+    --output text)
+
+echo "✓ Instance launched: $INSTANCE_ID"
+CREATED_INSTANCE="$INSTANCE_ID"
+
+# Wait for instance to be running
+echo ""
+echo "Waiting for instance to start..."
+aws ec2 wait instance-running --instance-ids "$INSTANCE_ID"
+echo "✓ Instance running"
+
+# Wait for SSM agent
+echo ""
+echo "Waiting for SSM agent (this may take 2-3 minutes)..."
+for i in {1..30}; do
+    if aws ssm describe-instance-information \
+        --filters "Key=InstanceIds,Values=$INSTANCE_ID" \
+        --query 'InstanceInformationList[0].InstanceId' \
+        --output text 2>/dev/null | grep -q "$INSTANCE_ID"; then
+        echo "✓ SSM agent connected"
+        break
+    fi
+    if [ $i -eq 30 ]; then
+        echo "⚠ SSM agent not responding. Instance may still be initializing."
+        echo "  Try again in a few minutes with: aws ssm start-session --target $INSTANCE_ID"
+    fi
+    sleep 10
+    echo "  Still waiting... ($i/30)"
+done
+
+# Wait for Engram installation
+echo ""
+echo "Waiting for Engram installation to complete..."
+for i in {1..20}; do
+    RESULT=$(aws ssm send-command \
+        --instance-ids "$INSTANCE_ID" \
+        --document-name "AWS-RunShellScript" \
+        --parameters 'commands=["test -f /home/ec2-user/.engram-ready && echo READY || echo WAITING"]' \
+        --query 'Command.CommandId' \
+        --output text 2>/dev/null) || true
+    
+    if [ -n "$RESULT" ]; then
+        sleep 3
+        STATUS=$(aws ssm get-command-invocation \
+            --command-id "$RESULT" \
+            --instance-id "$INSTANCE_ID" \
+            --query 'StandardOutputContent' \
+            --output text 2>/dev/null) || true
+        
+        if [[ "$STATUS" == *"READY"* ]]; then
+            echo "✓ Engram installed"
+            break
+        fi
+    fi
+    
+    if [ $i -eq 20 ]; then
+        echo "⚠ Installation check timed out. It may still be in progress."
+    fi
+    sleep 15
+    echo "  Installing... ($i/20)"
+done
+
+# Generate MCP config
+echo ""
+echo "=== Deployment Complete ==="
+echo ""
+echo "Instance ID: $INSTANCE_ID"
+echo "Key file: $ENGRAM_DIR/$KEY_NAME.pem"
+echo ""
+echo "Add this to your MCP client config:"
+echo ""
+cat << EOF
+{
+  "engram": {
+    "command": "ssh",
+    "args": [
+      "-i", "$ENGRAM_DIR/$KEY_NAME.pem",
+      "-o", "StrictHostKeyChecking=no",
+      "-o", "ProxyCommand=aws ssm start-session --target $INSTANCE_ID --document-name AWS-StartSSHSession --parameters portNumber=%p",
+      "ec2-user@$INSTANCE_ID",
+      "cd ~/engram && ENGRAM_DB_PATH=/data/engram/engram.db ~/.bun/bin/bun run src/index.ts"
+    ]
+  }
+}
+EOF
+
+echo ""
+echo "Test connection: aws ssm start-session --target $INSTANCE_ID"
+echo ""
+
+# Save instance info
+cat << EOF > "$ENGRAM_DIR/instance-info.txt"
+INSTANCE_ID=$INSTANCE_ID
+KEY_FILE=$ENGRAM_DIR/$KEY_NAME.pem
+REGION=$REGION
+CREATED=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+EOF
+
+echo "Instance info saved to: $ENGRAM_DIR/instance-info.txt"

--- a/scripts/destroy-aws.sh
+++ b/scripts/destroy-aws.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+set -e
+
+# Engram AWS Cleanup Script
+# Removes EC2 instance and associated resources created by deploy-aws.sh
+
+ENGRAM_DIR="${ENGRAM_DIR:-$HOME/.engram}"
+INFO_FILE="$ENGRAM_DIR/instance-info.txt"
+
+echo "=== Engram AWS Cleanup ==="
+echo ""
+
+# Check for instance info
+if [ ! -f "$INFO_FILE" ]; then
+    echo "No deployment found at $INFO_FILE"
+    echo ""
+    echo "Usage: $0 [instance-id]"
+    echo ""
+    echo "If you know your instance ID, pass it as an argument."
+    
+    if [ -n "$1" ]; then
+        INSTANCE_ID="$1"
+        KEY_FILE=""
+    else
+        exit 1
+    fi
+else
+    source "$INFO_FILE"
+    echo "Found deployment:"
+    echo "  Instance: $INSTANCE_ID"
+    echo "  Key file: $KEY_FILE"
+    echo "  Region:   $REGION"
+    echo "  Created:  $CREATED"
+fi
+
+# Allow override via argument
+if [ -n "$1" ]; then
+    INSTANCE_ID="$1"
+fi
+
+echo ""
+read -p "Delete this Engram deployment? (y/N) " confirm
+
+if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+    echo "Cancelled."
+    exit 0
+fi
+
+echo ""
+
+# Get key name from instance (if we don't have KEY_FILE)
+if [ -z "$KEY_FILE" ] && [ -n "$INSTANCE_ID" ]; then
+    KEY_NAME=$(aws ec2 describe-instances \
+        --instance-ids "$INSTANCE_ID" \
+        --query 'Reservations[0].Instances[0].KeyName' \
+        --output text 2>/dev/null) || true
+else
+    KEY_NAME=$(basename "${KEY_FILE:-.pem}" .pem)
+fi
+
+# Terminate instance
+if [ -n "$INSTANCE_ID" ]; then
+    echo "Terminating instance $INSTANCE_ID..."
+    if aws ec2 terminate-instances --instance-ids "$INSTANCE_ID" &>/dev/null; then
+        echo "✓ Instance terminating"
+    else
+        echo "⚠ Could not terminate instance (may already be terminated)"
+    fi
+fi
+
+# Delete key pair
+if [ -n "$KEY_NAME" ] && [ "$KEY_NAME" != "None" ]; then
+    echo "Deleting key pair $KEY_NAME..."
+    if aws ec2 delete-key-pair --key-name "$KEY_NAME" &>/dev/null; then
+        echo "✓ Key pair deleted from AWS"
+    else
+        echo "⚠ Could not delete key pair (may already be deleted)"
+    fi
+fi
+
+# Remove local key file
+if [ -n "$KEY_FILE" ] && [ -f "$KEY_FILE" ]; then
+    rm -f "$KEY_FILE"
+    echo "✓ Local key file removed"
+fi
+
+# Remove instance info
+if [ -f "$INFO_FILE" ]; then
+    rm -f "$INFO_FILE"
+    echo "✓ Instance info removed"
+fi
+
+echo ""
+echo "=== Cleanup Complete ==="
+echo ""
+echo "Note: IAM role 'engram-ec2-ssm-role' was NOT deleted (may be shared)."
+echo "To delete it manually:"
+echo "  aws iam remove-role-from-instance-profile --instance-profile-name engram-ec2-ssm-profile --role-name engram-ec2-ssm-role"
+echo "  aws iam delete-instance-profile --instance-profile-name engram-ec2-ssm-profile"
+echo "  aws iam detach-role-policy --role-name engram-ec2-ssm-role --policy-arn arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+echo "  aws iam delete-role --role-name engram-ec2-ssm-role"


### PR DESCRIPTION
Add scripts to deploy and manage Engram on AWS EC2:

- deploy-aws.sh: One-command deployment with SSM-based access
  - Launches t3.small with Amazon Linux 2023
  - Installs Bun and Engram via user-data
  - Creates IAM role for SSM (no public ports needed)
  - Outputs ready-to-use MCP client config
  - Auto-cleanup on failure via trap

- destroy-aws.sh: Clean removal of AWS resources
  - Terminates EC2 instance
  - Deletes key pair
  - Removes local files

Also updates README with AWS deployment option and cost estimate.