### PR TITLE
feat: implement compatibility primitives from engram RFC

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ remember({ content: "User prefers TypeScript over JavaScript", category: "prefer
 **Parameters:**
 - `content` (required): The memory content
 - `category` (optional): `decision`, `pattern`, `fact`, `preference`, `insight`
+- `scope_id`, `chat_id`, `thread_id`, `task_id` (optional): Scope filters for isolation (feature-flagged)
+- `metadata` (optional): Structured metadata object
+- `idempotency_key` (optional): Safe retry key (feature-flagged)
 
 ### `recall`
 
@@ -118,6 +121,7 @@ recall({ query: "coding preferences", limit: 5 })
 - `limit` (optional): Max results (default: 10)
 - `category` (optional): Filter by category
 - `min_strength` (optional): Minimum strength threshold (0.0-1.0)
+- `scope_id`, `chat_id`, `thread_id`, `task_id` (optional): Scope filters (feature-flagged)
 
 ### `forget`
 
@@ -129,10 +133,19 @@ forget({ id: "memory-uuid" })
 
 **Parameters:**
 - `id` (required): Memory ID to delete
+- `scope_id` (optional): Scope guard for deletion (required when `ENGRAM_ENABLE_SCOPES=1`)
 
 **Returns:**
 - `id`: Requested memory ID
 - `deleted`: `true` if a memory was deleted, `false` if it did not exist
+
+### `capabilities`
+
+Discover server version and feature flags for compatibility-safe client opt-in.
+
+### `context_hydrate`
+
+Retrieve contextual memories for assistant turns. Behavior mirrors `recall`, with `query` optional.
 
 When users ask to forget by phrase (for example, "forget the memory about API keys"),
 the assistant should first call `recall` to resolve candidates, then call `forget`
@@ -145,6 +158,14 @@ Database location: `~/.local/share/engram/engram.db`
 Override with environment variable:
 ```bash
 ENGRAM_DB_PATH=/custom/path/engram.db
+```
+
+Feature flags (all default to disabled):
+```bash
+ENGRAM_ENABLE_SCOPES=1
+ENGRAM_ENABLE_IDEMPOTENCY=1
+ENGRAM_ENABLE_CONTEXT_HYDRATION=1
+ENGRAM_ENABLE_WORK_ITEMS=1
 ```
 
 ## Development

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:cli": "bun build src/cli.ts --compile --outfile engram",
     "setup": "bun run scripts/setup.ts",
     "opencode:config": "bun run scripts/opencode-config.ts",
-    "test:core": "bun test test/db.test.ts test/cli.test.ts",
+    "test:core": "bun test test/db.test.ts test/cli.test.ts test/capabilities.test.ts test/http.test.ts",
     "test:full": "bun test",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint src/",

--- a/src/capabilities.ts
+++ b/src/capabilities.ts
@@ -1,0 +1,32 @@
+import { getConfig } from "./config";
+
+export interface CapabilitiesResponse {
+  version: string;
+  features: {
+    scopes: boolean;
+    idempotency: boolean;
+    context_hydration: boolean;
+    work_items: boolean;
+  };
+  tools: string[];
+}
+
+export function getCapabilities(version: string): CapabilitiesResponse {
+  const config = getConfig();
+  const tools = ["remember", "recall", "forget", "capabilities"];
+
+  if (config.features.contextHydration) {
+    tools.push("context_hydrate");
+  }
+
+  return {
+    version,
+    features: {
+      scopes: config.features.scopes,
+      idempotency: config.features.idempotency,
+      context_hydration: config.features.contextHydration,
+      work_items: config.features.workItems,
+    },
+    tools,
+  };
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,12 @@ export interface Config {
     model: string;
     cacheDir: string;
   };
+  features: {
+    scopes: boolean;
+    idempotency: boolean;
+    contextHydration: boolean;
+    workItems: boolean;
+  };
 }
 
 function expandPath(path: string): string {
@@ -56,6 +62,12 @@ export function getConfig(): Config {
     embedding: {
       model: process.env.ENGRAM_EMBEDDING_MODEL || "Xenova/bge-small-en-v1.5",
       cacheDir: join(dataDir, "models"),
+    },
+    features: {
+      scopes: process.env.ENGRAM_ENABLE_SCOPES === "1",
+      idempotency: process.env.ENGRAM_ENABLE_IDEMPOTENCY === "1",
+      contextHydration: process.env.ENGRAM_ENABLE_CONTEXT_HYDRATION === "1",
+      workItems: process.env.ENGRAM_ENABLE_WORK_ITEMS === "1",
     },
   };
 }

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -6,6 +6,12 @@ CREATE TABLE IF NOT EXISTS memories (
     id TEXT PRIMARY KEY,
     content TEXT NOT NULL,
     category TEXT,
+    scope_id TEXT,
+    chat_id TEXT,
+    thread_id TEXT,
+    task_id TEXT,
+    metadata_json TEXT,
+    idempotency_key TEXT,
     
     -- Temporal tracking
     created_at TEXT DEFAULT (datetime('now')),
@@ -23,6 +29,11 @@ CREATE TABLE IF NOT EXISTS memories (
 -- Indexes for common queries
 CREATE INDEX IF NOT EXISTS idx_memories_strength ON memories(strength);
 CREATE INDEX IF NOT EXISTS idx_memories_last_accessed ON memories(last_accessed);
+CREATE INDEX IF NOT EXISTS idx_memories_scope_id ON memories(scope_id);
+CREATE INDEX IF NOT EXISTS idx_memories_chat_id ON memories(chat_id);
+CREATE INDEX IF NOT EXISTS idx_memories_thread_id ON memories(thread_id);
+CREATE INDEX IF NOT EXISTS idx_memories_task_id ON memories(task_id);
+CREATE INDEX IF NOT EXISTS idx_memories_idempotency_key ON memories(idempotency_key);
 
 -- FTS5 virtual table for full-text search
 CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
@@ -60,3 +71,41 @@ CREATE TABLE IF NOT EXISTS metrics (
 -- Index for querying metrics by session
 CREATE INDEX IF NOT EXISTS idx_metrics_session_id ON metrics(session_id);
 CREATE INDEX IF NOT EXISTS idx_metrics_event ON metrics(event);
+
+-- Idempotency table for safe retries
+CREATE TABLE IF NOT EXISTS idempotency_ledger (
+    key TEXT NOT NULL,
+    operation TEXT NOT NULL,
+    scope_key TEXT NOT NULL,
+    scope_id TEXT,
+    created_at TEXT DEFAULT (datetime('now')),
+    result_json TEXT NOT NULL,
+    PRIMARY KEY (key, operation, scope_key)
+);
+
+-- Work item tables (optional feature; additive schema)
+CREATE TABLE IF NOT EXISTS work_items (
+    id TEXT PRIMARY KEY,
+    scope_id TEXT,
+    state TEXT NOT NULL,
+    owner TEXT,
+    payload_json TEXT,
+    result_json TEXT,
+    lease_expires_at TEXT,
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_work_items_state ON work_items(state);
+CREATE INDEX IF NOT EXISTS idx_work_items_scope_state ON work_items(scope_id, state);
+
+CREATE TABLE IF NOT EXISTS work_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    work_item_id TEXT NOT NULL,
+    event TEXT NOT NULL,
+    payload_json TEXT,
+    created_at TEXT DEFAULT (datetime('now')),
+    FOREIGN KEY (work_item_id) REFERENCES work_items(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_work_events_work_item_id ON work_events(work_item_id);

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,13 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
+import { getCapabilities } from "./capabilities";
+import { getConfig } from "./config";
 import { initDatabase } from "./db";
+import {
+  type ContextHydrateInput,
+  contextHydrate,
+} from "./tools/context-hydrate";
 import { type ForgetInput, forget } from "./tools/forget";
 import { type RecallInput, recall } from "./tools/recall";
 import { type RememberInput, remember } from "./tools/remember";
@@ -12,10 +18,12 @@ import { type RememberInput, remember } from "./tools/remember";
 // Initialize database on startup
 initDatabase();
 
+const VERSION = "0.1.0";
+
 const server = new Server(
   {
     name: "engram",
-    version: "0.1.0",
+    version: VERSION,
   },
   {
     capabilities: {
@@ -26,87 +34,194 @@ const server = new Server(
 
 // List available tools
 server.setRequestHandler(ListToolsRequestSchema, async () => {
+  const config = getConfig();
+  const tools: Array<Record<string, unknown>> = [
+    {
+      name: "remember",
+      description:
+        "Store a memory for later retrieval. Use this to save decisions, patterns, facts, preferences, or insights.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          content: {
+            type: "string",
+            description: "The memory content to store",
+          },
+          category: {
+            type: "string",
+            description:
+              "Optional category: decision, pattern, fact, preference, insight",
+            enum: ["decision", "pattern", "fact", "preference", "insight"],
+          },
+          session_id: {
+            type: "string",
+            description:
+              "Optional session identifier from the calling harness (e.g., OpenCode session ID)",
+          },
+          scope_id: {
+            type: "string",
+            description: "Optional scope identifier for isolation",
+          },
+          chat_id: {
+            type: "string",
+            description: "Optional chat identifier",
+          },
+          thread_id: {
+            type: "string",
+            description: "Optional thread identifier",
+          },
+          task_id: {
+            type: "string",
+            description: "Optional task identifier",
+          },
+          metadata: {
+            type: "object",
+            description: "Optional structured metadata",
+          },
+          idempotency_key: {
+            type: "string",
+            description: "Optional idempotency key for safe retries",
+          },
+        },
+        required: ["content"],
+      },
+    },
+    {
+      name: "recall",
+      description:
+        "Retrieve relevant memories. Returns memories ordered by relevance and strength.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description: "What to search for",
+          },
+          limit: {
+            type: "number",
+            description: "Maximum number of memories to return (default: 10)",
+          },
+          category: {
+            type: "string",
+            description: "Filter by category",
+            enum: ["decision", "pattern", "fact", "preference", "insight"],
+          },
+          min_strength: {
+            type: "number",
+            description: "Minimum strength threshold (0.0-1.0, default: 0.1)",
+          },
+          session_id: {
+            type: "string",
+            description:
+              "Optional session identifier from the calling harness (e.g., OpenCode session ID)",
+          },
+          scope_id: {
+            type: "string",
+            description: "Optional scope identifier for isolation",
+          },
+          chat_id: {
+            type: "string",
+            description: "Optional chat identifier",
+          },
+          thread_id: {
+            type: "string",
+            description: "Optional thread identifier",
+          },
+          task_id: {
+            type: "string",
+            description: "Optional task identifier",
+          },
+        },
+        required: ["query"],
+      },
+    },
+    {
+      name: "forget",
+      description: "Delete a stored memory by ID.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          id: {
+            type: "string",
+            description: "Memory ID to delete",
+          },
+          session_id: {
+            type: "string",
+            description:
+              "Optional session identifier from the calling harness (e.g., OpenCode session ID)",
+          },
+          scope_id: {
+            type: "string",
+            description: "Optional scope identifier guard",
+          },
+        },
+        required: ["id"],
+      },
+    },
+    {
+      name: "capabilities",
+      description:
+        "Discover supported engram features for compatibility-safe client opt-in.",
+      inputSchema: {
+        type: "object",
+        properties: {},
+      },
+    },
+  ];
+
+  if (config.features.contextHydration) {
+    tools.push({
+      name: "context_hydrate",
+      description:
+        "Hydrate contextual memories for an assistant turn. Equivalent to recall with optional empty query.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description:
+              "Optional query string; empty recalls recent/high-signal memories",
+          },
+          limit: {
+            type: "number",
+            description: "Maximum number of context entries",
+          },
+          category: {
+            type: "string",
+            description: "Optional category filter",
+            enum: ["decision", "pattern", "fact", "preference", "insight"],
+          },
+          min_strength: {
+            type: "number",
+            description: "Minimum strength threshold",
+          },
+          session_id: {
+            type: "string",
+            description: "Optional session identifier",
+          },
+          scope_id: {
+            type: "string",
+            description: "Optional scope identifier",
+          },
+          chat_id: {
+            type: "string",
+            description: "Optional chat identifier",
+          },
+          thread_id: {
+            type: "string",
+            description: "Optional thread identifier",
+          },
+          task_id: {
+            type: "string",
+            description: "Optional task identifier",
+          },
+        },
+      },
+    });
+  }
+
   return {
-    tools: [
-      {
-        name: "remember",
-        description:
-          "Store a memory for later retrieval. Use this to save decisions, patterns, facts, preferences, or insights.",
-        inputSchema: {
-          type: "object",
-          properties: {
-            content: {
-              type: "string",
-              description: "The memory content to store",
-            },
-            category: {
-              type: "string",
-              description:
-                "Optional category: decision, pattern, fact, preference, insight",
-              enum: ["decision", "pattern", "fact", "preference", "insight"],
-            },
-            session_id: {
-              type: "string",
-              description:
-                "Optional session identifier from the calling harness (e.g., OpenCode session ID)",
-            },
-          },
-          required: ["content"],
-        },
-      },
-      {
-        name: "recall",
-        description:
-          "Retrieve relevant memories. Returns memories ordered by relevance and strength.",
-        inputSchema: {
-          type: "object",
-          properties: {
-            query: {
-              type: "string",
-              description: "What to search for",
-            },
-            limit: {
-              type: "number",
-              description: "Maximum number of memories to return (default: 10)",
-            },
-            category: {
-              type: "string",
-              description: "Filter by category",
-              enum: ["decision", "pattern", "fact", "preference", "insight"],
-            },
-            min_strength: {
-              type: "number",
-              description: "Minimum strength threshold (0.0-1.0, default: 0.1)",
-            },
-            session_id: {
-              type: "string",
-              description:
-                "Optional session identifier from the calling harness (e.g., OpenCode session ID)",
-            },
-          },
-          required: ["query"],
-        },
-      },
-      {
-        name: "forget",
-        description: "Delete a stored memory by ID.",
-        inputSchema: {
-          type: "object",
-          properties: {
-            id: {
-              type: "string",
-              description: "Memory ID to delete",
-            },
-            session_id: {
-              type: "string",
-              description:
-                "Optional session identifier from the calling harness (e.g., OpenCode session ID)",
-            },
-          },
-          required: ["id"],
-        },
-      },
-    ],
+    tools,
   };
 });
 
@@ -152,7 +267,41 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       if (!input.id) {
         throw new Error("id is required");
       }
+      const config = getConfig();
+      if (config.features.scopes && !input.scope_id) {
+        throw new Error("scope_id is required when scopes are enabled");
+      }
       const result = await forget(input);
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    }
+
+    case "capabilities": {
+      const result = getCapabilities(VERSION);
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    }
+
+    case "context_hydrate": {
+      const config = getConfig();
+      if (!config.features.contextHydration) {
+        throw new Error("context_hydrate is disabled");
+      }
+
+      const input = (args ?? {}) as unknown as ContextHydrateInput;
+      const result = await contextHydrate(input);
       return {
         content: [
           {

--- a/src/tools/context-hydrate.ts
+++ b/src/tools/context-hydrate.ts
@@ -1,0 +1,24 @@
+import { type RecallInput, type RecallMemory, recall } from "./recall";
+
+export interface ContextHydrateInput extends Omit<RecallInput, "query"> {
+  query?: string;
+}
+
+export interface ContextHydrateOutput {
+  context: RecallMemory[];
+  fallback_mode: boolean;
+}
+
+export async function contextHydrate(
+  input: ContextHydrateInput,
+): Promise<ContextHydrateOutput> {
+  const result = await recall({
+    ...input,
+    query: input.query ?? "",
+  });
+
+  return {
+    context: result.memories,
+    fallback_mode: result.fallback_mode,
+  };
+}

--- a/src/tools/forget.ts
+++ b/src/tools/forget.ts
@@ -1,8 +1,10 @@
+import { getConfig } from "../config";
 import { deleteMemoryById, logMetric } from "../db";
 
 export interface ForgetInput {
   id: string;
   session_id?: string;
+  scope_id?: string;
 }
 
 export interface ForgetOutput {
@@ -11,7 +13,15 @@ export interface ForgetOutput {
 }
 
 export async function forget(input: ForgetInput): Promise<ForgetOutput> {
-  const deleted = deleteMemoryById(input.id);
+  const config = getConfig();
+  if (config.features.scopes && !input.scope_id) {
+    throw new Error("scope_id is required when scopes are enabled");
+  }
+
+  const deleted = deleteMemoryById(
+    input.id,
+    config.features.scopes ? input.scope_id : undefined,
+  );
 
   logMetric({
     session_id: input.session_id,

--- a/src/tools/remember.ts
+++ b/src/tools/remember.ts
@@ -1,10 +1,22 @@
-import { createMemory, logMetric } from "../db";
+import { getConfig } from "../config";
+import {
+  createMemory,
+  getIdempotencyResult,
+  logMetric,
+  saveIdempotencyResult,
+} from "../db";
 import { embed, embeddingToBuffer } from "../embedding";
 
 export interface RememberInput {
   content: string;
   category?: string;
   session_id?: string;
+  scope_id?: string;
+  chat_id?: string;
+  thread_id?: string;
+  task_id?: string;
+  metadata?: Record<string, unknown>;
+  idempotency_key?: string;
 }
 
 export interface RememberOutput {
@@ -13,6 +25,22 @@ export interface RememberOutput {
 }
 
 export async function remember(input: RememberInput): Promise<RememberOutput> {
+  const config = getConfig();
+  const scopeIdForIdempotency = config.features.scopes
+    ? input.scope_id
+    : undefined;
+
+  if (config.features.idempotency && input.idempotency_key) {
+    const existing = getIdempotencyResult<RememberOutput>(
+      input.idempotency_key,
+      "remember",
+      scopeIdForIdempotency,
+    );
+    if (existing) {
+      return existing;
+    }
+  }
+
   const id = crypto.randomUUID();
 
   // Generate embedding for semantic search
@@ -23,6 +51,14 @@ export async function remember(input: RememberInput): Promise<RememberOutput> {
     id,
     content: input.content,
     category: input.category,
+    scope_id: config.features.scopes ? input.scope_id : undefined,
+    chat_id: config.features.scopes ? input.chat_id : undefined,
+    thread_id: config.features.scopes ? input.thread_id : undefined,
+    task_id: config.features.scopes ? input.task_id : undefined,
+    metadata_json: input.metadata ? JSON.stringify(input.metadata) : undefined,
+    idempotency_key: config.features.idempotency
+      ? input.idempotency_key
+      : undefined,
     embedding: embeddingBuffer,
   });
 
@@ -33,5 +69,16 @@ export async function remember(input: RememberInput): Promise<RememberOutput> {
     memory_id: id,
   });
 
-  return { id };
+  const output = { id };
+
+  if (config.features.idempotency && input.idempotency_key) {
+    saveIdempotencyResult(
+      input.idempotency_key,
+      "remember",
+      scopeIdForIdempotency,
+      output,
+    );
+  }
+
+  return output;
 }

--- a/test/capabilities.test.ts
+++ b/test/capabilities.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { getCapabilities } from "../src/capabilities";
+import {
+  closeDatabase,
+  createMemory,
+  initDatabase,
+  resetDatabase,
+} from "../src/db";
+import { resetEmbedder } from "../src/embedding";
+import { contextHydrate } from "../src/tools/context-hydrate";
+
+describe("capabilities and context hydration", () => {
+  const originalScopes = process.env.ENGRAM_ENABLE_SCOPES;
+  const originalIdempotency = process.env.ENGRAM_ENABLE_IDEMPOTENCY;
+  const originalContext = process.env.ENGRAM_ENABLE_CONTEXT_HYDRATION;
+  const originalWorkItems = process.env.ENGRAM_ENABLE_WORK_ITEMS;
+
+  beforeEach(() => {
+    process.env.ENGRAM_ENABLE_SCOPES = "0";
+    process.env.ENGRAM_ENABLE_IDEMPOTENCY = "0";
+    process.env.ENGRAM_ENABLE_CONTEXT_HYDRATION = "0";
+    process.env.ENGRAM_ENABLE_WORK_ITEMS = "0";
+    resetDatabase();
+    resetEmbedder();
+    initDatabase(":memory:");
+  });
+
+  afterEach(() => {
+    closeDatabase();
+
+    if (originalScopes === undefined) {
+      delete process.env.ENGRAM_ENABLE_SCOPES;
+    } else {
+      process.env.ENGRAM_ENABLE_SCOPES = originalScopes;
+    }
+
+    if (originalIdempotency === undefined) {
+      delete process.env.ENGRAM_ENABLE_IDEMPOTENCY;
+    } else {
+      process.env.ENGRAM_ENABLE_IDEMPOTENCY = originalIdempotency;
+    }
+
+    if (originalContext === undefined) {
+      delete process.env.ENGRAM_ENABLE_CONTEXT_HYDRATION;
+    } else {
+      process.env.ENGRAM_ENABLE_CONTEXT_HYDRATION = originalContext;
+    }
+
+    if (originalWorkItems === undefined) {
+      delete process.env.ENGRAM_ENABLE_WORK_ITEMS;
+    } else {
+      process.env.ENGRAM_ENABLE_WORK_ITEMS = originalWorkItems;
+    }
+  });
+
+  test("returns feature flags through capabilities", () => {
+    process.env.ENGRAM_ENABLE_SCOPES = "1";
+    process.env.ENGRAM_ENABLE_IDEMPOTENCY = "1";
+    process.env.ENGRAM_ENABLE_CONTEXT_HYDRATION = "1";
+
+    const caps = getCapabilities("0.1.0");
+    expect(caps.features.scopes).toBe(true);
+    expect(caps.features.idempotency).toBe(true);
+    expect(caps.features.context_hydration).toBe(true);
+    expect(caps.tools).toContain("capabilities");
+    expect(caps.tools).toContain("context_hydrate");
+  });
+
+  test("hides context_hydrate when feature is disabled", () => {
+    const caps = getCapabilities("0.1.0");
+    expect(caps.features.context_hydration).toBe(false);
+    expect(caps.tools).not.toContain("context_hydrate");
+  });
+
+  test("hydrates context from recall fallback path", async () => {
+    createMemory({ id: "m1", content: "First context memory" });
+    createMemory({ id: "m2", content: "Second context memory" });
+
+    const result = await contextHydrate({ limit: 1 });
+    expect(result.context).toHaveLength(1);
+    expect(result.fallback_mode).toBe(true);
+  });
+});

--- a/test/forget.test.ts
+++ b/test/forget.test.ts
@@ -11,7 +11,10 @@ import { forget } from "../src/tools/forget";
 import { remember } from "../src/tools/remember";
 
 describe("forget tool", () => {
+  const originalScopes = process.env.ENGRAM_ENABLE_SCOPES;
+
   beforeEach(() => {
+    process.env.ENGRAM_ENABLE_SCOPES = "0";
     resetDatabase();
     resetEmbedder();
     initDatabase(":memory:");
@@ -19,6 +22,12 @@ describe("forget tool", () => {
 
   afterEach(() => {
     closeDatabase();
+
+    if (originalScopes === undefined) {
+      delete process.env.ENGRAM_ENABLE_SCOPES;
+    } else {
+      process.env.ENGRAM_ENABLE_SCOPES = originalScopes;
+    }
   });
 
   test("deletes a stored memory", async () => {
@@ -47,5 +56,13 @@ describe("forget tool", () => {
     const summary = getMetricsSummary("session-forget");
     expect(summary.total_remembers).toBe(1);
     expect(summary.total_recalls).toBe(0);
+  });
+
+  test("requires scope_id when scopes are enabled", async () => {
+    process.env.ENGRAM_ENABLE_SCOPES = "1";
+
+    await expect(forget({ id: "missing-scope" })).rejects.toThrow(
+      "scope_id is required when scopes are enabled",
+    );
   });
 });

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { closeDatabase, initDatabase, resetDatabase } from "../src/db";
+import { startHttpServer } from "../src/http";
+
+describe("http server", () => {
+  const originalPort = process.env.ENGRAM_HTTP_PORT;
+  const originalHost = process.env.ENGRAM_HTTP_HOST;
+  const originalScopes = process.env.ENGRAM_ENABLE_SCOPES;
+  const originalContext = process.env.ENGRAM_ENABLE_CONTEXT_HYDRATION;
+
+  beforeEach(() => {
+    process.env.ENGRAM_HTTP_PORT = "0";
+    process.env.ENGRAM_HTTP_HOST = "127.0.0.1";
+    process.env.ENGRAM_ENABLE_SCOPES = "0";
+    process.env.ENGRAM_ENABLE_CONTEXT_HYDRATION = "0";
+    resetDatabase();
+    initDatabase(":memory:");
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    resetDatabase();
+
+    if (originalPort === undefined) {
+      delete process.env.ENGRAM_HTTP_PORT;
+    } else {
+      process.env.ENGRAM_HTTP_PORT = originalPort;
+    }
+
+    if (originalHost === undefined) {
+      delete process.env.ENGRAM_HTTP_HOST;
+    } else {
+      process.env.ENGRAM_HTTP_HOST = originalHost;
+    }
+
+    if (originalScopes === undefined) {
+      delete process.env.ENGRAM_ENABLE_SCOPES;
+    } else {
+      process.env.ENGRAM_ENABLE_SCOPES = originalScopes;
+    }
+
+    if (originalContext === undefined) {
+      delete process.env.ENGRAM_ENABLE_CONTEXT_HYDRATION;
+    } else {
+      process.env.ENGRAM_ENABLE_CONTEXT_HYDRATION = originalContext;
+    }
+  });
+
+  test("requires scope_id for forget when scopes feature enabled", async () => {
+    process.env.ENGRAM_ENABLE_SCOPES = "1";
+    const server = startHttpServer();
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${server.port}/forget`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id: "memory-1" }),
+      });
+
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("scope_id is required when scopes are enabled");
+    } finally {
+      server.stop();
+    }
+  });
+
+  test("capabilities hides context_hydrate when disabled", async () => {
+    const server = startHttpServer();
+
+    try {
+      const response = await fetch(
+        `http://127.0.0.1:${server.port}/capabilities`,
+      );
+      expect(response.status).toBe(200);
+
+      const body = (await response.json()) as {
+        tools: string[];
+        features: { context_hydration: boolean };
+      };
+
+      expect(body.features.context_hydration).toBe(false);
+      expect(body.tools).not.toContain("context_hydrate");
+    } finally {
+      server.stop();
+    }
+  });
+});

--- a/test/remember.test.ts
+++ b/test/remember.test.ts
@@ -9,7 +9,12 @@ import { resetEmbedder } from "../src/embedding";
 import { remember } from "../src/tools/remember";
 
 describe("remember tool", () => {
+  const originalScopes = process.env.ENGRAM_ENABLE_SCOPES;
+  const originalIdempotency = process.env.ENGRAM_ENABLE_IDEMPOTENCY;
+
   beforeEach(() => {
+    process.env.ENGRAM_ENABLE_SCOPES = "0";
+    process.env.ENGRAM_ENABLE_IDEMPOTENCY = "0";
     resetDatabase();
     resetEmbedder();
     initDatabase(":memory:");
@@ -17,6 +22,18 @@ describe("remember tool", () => {
 
   afterEach(() => {
     closeDatabase();
+
+    if (originalScopes === undefined) {
+      delete process.env.ENGRAM_ENABLE_SCOPES;
+    } else {
+      process.env.ENGRAM_ENABLE_SCOPES = originalScopes;
+    }
+
+    if (originalIdempotency === undefined) {
+      delete process.env.ENGRAM_ENABLE_IDEMPOTENCY;
+    } else {
+      process.env.ENGRAM_ENABLE_IDEMPOTENCY = originalIdempotency;
+    }
   });
 
   test("stores a memory and returns an ID", async () => {
@@ -64,5 +81,59 @@ describe("remember tool", () => {
     // Embedding should be a Buffer with float32 data
     // bge-small-en-v1.5 produces 384-dim embeddings = 384 * 4 bytes = 1536 bytes
     expect(stored!.embedding!.length).toBe(384 * 4);
+  });
+
+  test("stores scoped fields when scopes feature is enabled", async () => {
+    process.env.ENGRAM_ENABLE_SCOPES = "1";
+
+    const result = await remember({
+      content: "Scoped memory",
+      scope_id: "project-a",
+      chat_id: "chat-1",
+      thread_id: "thread-1",
+      task_id: "task-1",
+      metadata: { source: "test" },
+    });
+
+    const stored = getMemoryById(result.id);
+    expect(stored!.scope_id).toBe("project-a");
+    expect(stored!.chat_id).toBe("chat-1");
+    expect(stored!.thread_id).toBe("thread-1");
+    expect(stored!.task_id).toBe("task-1");
+    expect(stored!.metadata_json).toBe('{"source":"test"}');
+  });
+
+  test("returns same result for duplicate idempotency key when enabled", async () => {
+    process.env.ENGRAM_ENABLE_IDEMPOTENCY = "1";
+
+    const first = await remember({
+      content: "Idempotent memory",
+      idempotency_key: "remember-key-1",
+    });
+    const second = await remember({
+      content: "Idempotent memory",
+      idempotency_key: "remember-key-1",
+    });
+
+    expect(second.id).toBe(first.id);
+  });
+
+  test("does not collide idempotency keys across scopes", async () => {
+    process.env.ENGRAM_ENABLE_IDEMPOTENCY = "1";
+    process.env.ENGRAM_ENABLE_SCOPES = "1";
+
+    const first = await remember({
+      content: "Scoped idempotency A",
+      scope_id: "project-a",
+      idempotency_key: "shared-key",
+    });
+
+    const second = await remember({
+      content: "Scoped idempotency B",
+      scope_id: "project-b",
+      idempotency_key: "shared-key",
+    });
+
+    expect(first.id).not.toBe(second.id);
   });
 });


### PR DESCRIPTION
## Summary
- implement additive, backward-compatible primitives from the multi-agent RFC without changing existing required client inputs
- add feature-flagged scope and idempotency fields across memory APIs, plus capability discovery and context hydration surfaces
- extend schema/migrations and tests to support opt-in rollout while preserving default behavior

## Validation
- `bun run validate` passes
- `bun run validate:full` runs all tests successfully (`62 pass / 0 fail`) but exits with known Bun SIGTRAP 133 crash documented in repo