### PR TITLE
fix: ensure scoped memory indexes are created during legacy migrations

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -133,6 +133,14 @@ function runMigrations(database: Database): void {
     }
   }
 
+  database.exec(`
+    CREATE INDEX IF NOT EXISTS idx_memories_scope_id ON memories(scope_id);
+    CREATE INDEX IF NOT EXISTS idx_memories_chat_id ON memories(chat_id);
+    CREATE INDEX IF NOT EXISTS idx_memories_thread_id ON memories(thread_id);
+    CREATE INDEX IF NOT EXISTS idx_memories_task_id ON memories(task_id);
+    CREATE INDEX IF NOT EXISTS idx_memories_idempotency_key ON memories(idempotency_key);
+  `);
+
   // Ensure additive tables exist for old databases
   database.exec(`
     CREATE TABLE IF NOT EXISTS idempotency_ledger (

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -29,11 +29,6 @@ CREATE TABLE IF NOT EXISTS memories (
 -- Indexes for common queries
 CREATE INDEX IF NOT EXISTS idx_memories_strength ON memories(strength);
 CREATE INDEX IF NOT EXISTS idx_memories_last_accessed ON memories(last_accessed);
-CREATE INDEX IF NOT EXISTS idx_memories_scope_id ON memories(scope_id);
-CREATE INDEX IF NOT EXISTS idx_memories_chat_id ON memories(chat_id);
-CREATE INDEX IF NOT EXISTS idx_memories_thread_id ON memories(thread_id);
-CREATE INDEX IF NOT EXISTS idx_memories_task_id ON memories(task_id);
-CREATE INDEX IF NOT EXISTS idx_memories_idempotency_key ON memories(idempotency_key);
 
 -- FTS5 virtual table for full-text search
 CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(


### PR DESCRIPTION
## Summary
- Move scoped memory index creation into runtime migrations so existing databases that predate scoped columns do not fail migration order.
- Keep `schema.sql` focused on base table/index setup while migration code handles additive index creation safely.
- Add a regression test that boots from a legacy `memories` schema and verifies scoped columns and indexes are present after initialization.

## Validation
- bun run validate