### PR TITLE
feat: improve retrieval quality with strength-weighted ranking, access boost cap, metadata filtering

### DIFF
--- a/opencode/plugins/engram.ts
+++ b/opencode/plugins/engram.ts
@@ -14,6 +14,7 @@ import type { Plugin } from "@opencode-ai/plugin";
 const DEBOUNCE_MS = 60_000; // 60 seconds
 const MAX_MESSAGES_FOR_CONTEXT = 20; // Last N messages to extract from
 const ENGRAM_URL = "http://127.0.0.1:7749";
+const AUTO_EXTRACT_ENABLED = process.env.ENGRAM_PLUGIN_AUTO_EXTRACT !== "0"; // Enabled by default, set to "0" to disable
 
 export const EngramPlugin: Plugin = async ({ client, $ }) => {
   // Track last extraction time per session for debouncing
@@ -176,6 +177,11 @@ Before continuing, use engram_recall to retrieve relevant memories that may help
      */
     event: async ({ event }) => {
       if (event.type === "session.idle") {
+        // Skip extraction if auto-extract is disabled
+        if (!AUTO_EXTRACT_ENABLED) {
+          return;
+        }
+
         const sessionId = event.properties.sessionID;
         const now = Date.now();
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,8 @@ export interface Config {
     rate: number;
     /** Strength to set when a memory is accessed */
     accessBoostStrength: number;
+    /** Maximum access count boost multiplier (caps log-based boost) */
+    maxAccessBoost: number;
   };
   http: {
     port: number;
@@ -66,6 +68,9 @@ export function getConfig(): Config {
       accessBoostStrength: process.env.ENGRAM_ACCESS_BOOST_STRENGTH
         ? parseFloat(process.env.ENGRAM_ACCESS_BOOST_STRENGTH)
         : 1.0,
+      maxAccessBoost: process.env.ENGRAM_DECAY_MAX_ACCESS_BOOST
+        ? parseFloat(process.env.ENGRAM_DECAY_MAX_ACCESS_BOOST)
+        : 2.0,
     },
     http: {
       port: process.env.ENGRAM_HTTP_PORT

--- a/src/db/decay.ts
+++ b/src/db/decay.ts
@@ -43,8 +43,10 @@ export function calculateDecayedStrength(
   // Calculate final strength
   // Normalize access boost so that access_count=1 gives boost of 1.0
   // log(2) ≈ 0.693, so we divide by log(2) to normalize
+  // Cap the boost to prevent frequently-accessed memories from dominating
   const normalizedBoost = accessBoost / Math.log(2);
-  const decayedStrength = baseStrength * decayFactor * normalizedBoost;
+  const cappedBoost = Math.min(normalizedBoost, config.decay.maxAccessBoost);
+  const decayedStrength = baseStrength * decayFactor * cappedBoost;
 
   // Cap at 1.0
   return Math.min(Math.max(decayedStrength, 0), 1.0);

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -536,6 +536,7 @@ export interface MemoryWithEmbedding {
   chat_id: string | null;
   thread_id: string | null;
   task_id: string | null;
+  metadata_json: string | null;
   strength: number;
   created_at: string;
   last_accessed: string;
@@ -555,7 +556,7 @@ export function getAllMemoriesWithEmbeddings(
   applyMemoryFilters(filters, clauses, params);
   const whereClause = `WHERE ${clauses.join(" AND ")}`;
   const stmt = database.prepare(
-    `SELECT id, content, category, scope_id, chat_id, thread_id, task_id, strength, created_at, last_accessed, access_count, embedding FROM memories ${whereClause}`,
+    `SELECT id, content, category, scope_id, chat_id, thread_id, task_id, metadata_json, strength, created_at, last_accessed, access_count, embedding FROM memories ${whereClause}`,
   );
   return stmt.all(params) as MemoryWithEmbedding[];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,6 +131,11 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             type: "string",
             description: "Optional task identifier",
           },
+          metadata_filter: {
+            type: "object",
+            description:
+              "Optional metadata filter. Exact-match on top-level keys, AND logic. E.g. { needs_review: true }",
+          },
         },
         required: ["query"],
       },


### PR DESCRIPTION
Retrieval was not leveraging the full architecture - decay/strength was decorative during semantic search (pure cosine sort), access boost was unbounded, and there was no way to filter by metadata.

Changes:
- Strength-weighted ranking: relevance = similarity * decayedStrength (was pure cosine)
- Access boost cap: `min(log(accessCount+1)/log(2), 2.0)` prevents popular memories from dominating
- `metadata_filter` parameter in `recall()` for exact-match AND logic on metadata_json
- OpenCode plugin auto-extraction configurable via `ENGRAM_PLUGIN_AUTO_EXTRACT=0`
- PLAN.md: add Slice 5.5, rewrite Slice 6 for agent-driven intelligence pattern