### PR TITLE
feat: add version bump script for minor/major releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,11 +40,25 @@ jobs:
           # Strip 'v' prefix and split into major.minor.patch
           VERSION="${LATEST_TAG#v}"
           IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
-          NEXT_PATCH=$((PATCH + 1))
-          NEXT_VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}"
+
+          # Scan commits since last tag for [minor] or [major] bump markers
+          # created by: bun run version:bump <minor|major>
+          COMMITS_SINCE="$(git log "${LATEST_TAG}..HEAD" --format='%s' 2>/dev/null || echo "")"
+          if echo "$COMMITS_SINCE" | grep -q '\[major\]'; then
+            NEXT_VERSION="$((MAJOR + 1)).0.0"
+            BUMP_LEVEL="major"
+          elif echo "$COMMITS_SINCE" | grep -q '\[minor\]'; then
+            NEXT_VERSION="${MAJOR}.$((MINOR + 1)).0"
+            BUMP_LEVEL="minor"
+          else
+            NEXT_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+            BUMP_LEVEL="patch"
+          fi
+
+          echo "bump_level=${BUMP_LEVEL}" >> "$GITHUB_OUTPUT"
           echo "next_version=${NEXT_VERSION}" >> "$GITHUB_OUTPUT"
           echo "next_tag=v${NEXT_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Releasing: v${NEXT_VERSION} (previous: ${LATEST_TAG})"
+          echo "Releasing: v${NEXT_VERSION} (previous: ${LATEST_TAG}, bump: ${BUMP_LEVEL})"
 
       - name: Write VERSION file
         run: echo "${{ steps.version.outputs.next_version }}" > VERSION

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "format:check": "biome check src/ test/",
     "validate": "bun run typecheck && bun run lint && bun run format:check && bun run test:core",
     "validate:full": "bun run typecheck && bun run lint && bun run format:check && bun run test:full",
+    "version:bump": "bun run scripts/version-bump.ts",
     "prepare": "husky"
   },
   "dependencies": {

--- a/scripts/version-bump.ts
+++ b/scripts/version-bump.ts
@@ -1,0 +1,136 @@
+/**
+ * Creates a version bump marker commit for the release workflow.
+ *
+ * Usage:
+ *   bun run version:bump minor   # next release bumps minor (e.g. 0.1.18 -> 0.2.0)
+ *   bun run version:bump major   # next release bumps major (e.g. 0.1.18 -> 1.0.0)
+ *
+ * Patch bumps are the default in the release workflow and need no marker.
+ *
+ * The script creates an empty commit with a [minor] or [major] tag in the
+ * message. The release workflow scans all commits since the last tag for
+ * these markers to determine the bump level.
+ */
+
+type BumpLevel = "minor" | "major";
+
+const VALID_BUMPS: ReadonlySet<string> = new Set(["minor", "major"]);
+
+const run = (cmd: string[]): { stdout: string; exitCode: number } => {
+  const result = Bun.spawnSync({
+    cmd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return {
+    stdout: new TextDecoder().decode(result.stdout).trim(),
+    exitCode: result.exitCode,
+  };
+};
+
+const fail = (message: string): never => {
+  console.error(`error: ${message}`);
+  return process.exit(1) as never;
+};
+
+const getLatestTag = (): string => {
+  const { stdout, exitCode } = run(["git", "describe", "--tags", "--abbrev=0"]);
+  if (exitCode !== 0 || !stdout.startsWith("v")) {
+    fail("no git tags found. Create an initial tag (e.g. v0.1.0) first.");
+  }
+  return stdout;
+};
+
+const parseVersion = (tag: string): [number, number, number] => {
+  const match = tag.match(/^v(\d+)\.(\d+)\.(\d+)$/);
+  if (!match) {
+    return fail(`cannot parse tag "${tag}" as semver.`);
+  }
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+};
+
+const computeNext = (
+  current: [number, number, number],
+  bump: BumpLevel,
+): string => {
+  const [major, minor] = current;
+  if (bump === "major") {
+    return `${major + 1}.0.0`;
+  }
+  return `${major}.${minor + 1}.0`;
+};
+
+const assertCleanTree = (): void => {
+  const { stdout } = run(["git", "status", "--porcelain"]);
+  if (stdout.length > 0) {
+    fail(
+      "working tree is dirty. Commit or stash changes first.\n" +
+        "  (version bump creates an empty commit and requires a clean tree)",
+    );
+  }
+};
+
+const assertNoPendingBump = (latestTag: string, bump: BumpLevel): void => {
+  const { stdout } = run(["git", "log", `${latestTag}..HEAD`, "--format=%s"]);
+  if (stdout.includes(`[${bump}]`)) {
+    fail(
+      `a [${bump}] bump marker already exists in commits since ${latestTag}.\n` +
+        "  There is no need to run this again.",
+    );
+  }
+  // Warn if there's a different bump already pending
+  const other: BumpLevel = bump === "minor" ? "major" : "minor";
+  if (stdout.includes(`[${other}]`)) {
+    console.warn(
+      `warning: a [${other}] bump marker already exists since ${latestTag}.` +
+        ` Adding [${bump}] — the release workflow will use the higher of the two.`,
+    );
+  }
+};
+
+// --- main ---
+
+const bumpArg = process.argv[2];
+
+if (!bumpArg || !VALID_BUMPS.has(bumpArg)) {
+  console.error("usage: bun run version:bump <minor|major>");
+  console.error("");
+  console.error(
+    "  minor   bump minor version, reset patch (e.g. 0.1.18 -> 0.2.0)",
+  );
+  console.error(
+    "  major   bump major version, reset minor + patch (e.g. 0.1.18 -> 1.0.0)",
+  );
+  console.error("");
+  console.error("  Patch bumps are automatic and need no marker.");
+  process.exit(1);
+}
+
+const bump = bumpArg as BumpLevel;
+const latestTag = getLatestTag();
+const current = parseVersion(latestTag);
+const next = computeNext(current, bump);
+
+assertCleanTree();
+assertNoPendingBump(latestTag, bump);
+
+const commitMessage = `chore: version bump v${next} [${bump}]`;
+
+const commitResult = run([
+  "git",
+  "commit",
+  "--allow-empty",
+  "-m",
+  commitMessage,
+]);
+
+if (commitResult.exitCode !== 0) {
+  fail("git commit failed.");
+}
+
+console.log("");
+console.log(`  current version:  ${latestTag}`);
+console.log(`  next version:     v${next} (${bump} bump)`);
+console.log("");
+console.log(`  created commit: ${commitMessage}`);
+console.log("");


### PR DESCRIPTION
## Summary

- Add `scripts/version-bump.ts` helper that creates empty marker commits (`[minor]` or `[major]`) so the release workflow knows which semver component to bump
- Update `.github/workflows/release.yml` to scan commit messages since the last tag for bump markers, defaulting to patch when none are found
- Add `version:bump` script to `package.json`

## Usage

```bash
bun run version:bump minor   # 0.1.18 -> 0.2.0
bun run version:bump major   # 0.1.18 -> 1.0.0
# patch bumps remain automatic (no marker needed)
```

## Notes

- The script enforces a clean working tree and prevents duplicate markers
- If both `[minor]` and `[major]` markers exist, the workflow picks the higher bump