### PR TITLE
fix: consistent health endpoint status

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -75,7 +75,7 @@ async function handleRequest(req: Request): Promise<Response> {
     if (path === "/health" && method === "GET") {
       return Response.json(
         {
-          status: "ok",
+          status: "healthy",
           version: VERSION,
           uptime: Math.floor((Date.now() - startTime) / 1000),
         },


### PR DESCRIPTION
## Summary
- Change health endpoint response from `"status": "ok"` to `"status": "healthy"` to match Synapse's convention
- Wilson's `wilson health` command expects `"healthy"` and displays anything else as "degraded"
- One-line change in `src/http.ts:78`, no test changes needed