### PR TITLE
feat: add upsert support to POST /remember for topic summary updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,18 @@ remember({ content: "User prefers TypeScript over JavaScript", category: "prefer
 **Parameters:**
 - `content` (required): The memory content
 - `category` (optional): `decision`, `pattern`, `fact`, `preference`, `insight`
-- `scope_id`, `chat_id`, `thread_id`, `task_id` (optional): Scope filters for isolation (feature-flagged)
+- `scope_id`, `chat_id`, `thread_id`, `task_id` (optional): Scope filters for isolation
 - `metadata` (optional): Structured metadata object
-- `idempotency_key` (optional): Safe retry key (feature-flagged)
+- `idempotency_key` (optional): Safe retry key
+- `upsert` (optional): When `true`, update the existing memory matching the `idempotency_key` instead of creating a new one. Requires `idempotency_key`.
+
+**Returns:** `{ id: string, status: "created" | "updated" }`
+
+**Upsert behavior:**
+- When `upsert: true` and a memory with the same `idempotency_key` (and `scope_id`) exists: overwrites `content`, `category`, `metadata`, and `embedding`. Does not change `created_at`, `access_count`, `strength`, or scope fields.
+- Uses full-replace semantics: omitted optional fields (`category`, `metadata`) are set to `null`.
+- When no match exists: creates a new memory normally.
+- When `upsert` is omitted or `false`: standard idempotency replay (returns cached result, no mutation).
 
 ### `recall`
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -98,6 +98,13 @@ async function handleRequest(req: Request): Promise<Response> {
         );
       }
 
+      if (body.upsert && !body.idempotency_key) {
+        return Response.json(
+          { error: "upsert requires idempotency_key" },
+          { status: 400, headers },
+        );
+      }
+
       const result = await remember(body);
       return Response.json(result, { headers });
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,11 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             type: "string",
             description: "Optional idempotency key for safe retries",
           },
+          upsert: {
+            type: "boolean",
+            description:
+              "When true, update the existing memory matching the idempotency_key instead of creating a new one. Requires idempotency_key. Uses full-replace semantics: omitted optional fields are set to null.",
+          },
         },
         required: ["content"],
       },
@@ -233,6 +238,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       const input = args as unknown as RememberInput;
       if (!input.content) {
         throw new Error("content is required");
+      }
+      if (input.upsert && !input.idempotency_key) {
+        throw new Error("upsert requires idempotency_key");
       }
       const result = await remember(input);
       return {

--- a/src/tools/remember.ts
+++ b/src/tools/remember.ts
@@ -1,9 +1,11 @@
 import { getConfig } from "../config";
 import {
   createMemory,
+  findMemoryByIdempotencyKey,
   getIdempotencyResult,
   logMetric,
   saveIdempotencyResult,
+  updateMemoryContent,
 } from "../db";
 import { embed, embeddingToBuffer } from "../embedding";
 
@@ -17,11 +19,12 @@ export interface RememberInput {
   task_id?: string;
   metadata?: Record<string, unknown>;
   idempotency_key?: string;
+  upsert?: boolean;
 }
 
 export interface RememberOutput {
   id: string;
-  // Future: merged_with, conflict_detected, conflict_with
+  status: "created" | "updated";
 }
 
 export async function remember(input: RememberInput): Promise<RememberOutput> {
@@ -30,20 +33,68 @@ export async function remember(input: RememberInput): Promise<RememberOutput> {
     ? input.scope_id
     : undefined;
 
-  if (config.features.idempotency && input.idempotency_key) {
-    const existing = getIdempotencyResult<RememberOutput>(
+  // Upsert path: check for existing memory by idempotency_key, update if found
+  if (input.upsert) {
+    if (!input.idempotency_key) {
+      throw new Error("upsert requires idempotency_key");
+    }
+
+    const existing = findMemoryByIdempotencyKey(
+      input.idempotency_key,
+      scopeIdForIdempotency,
+    );
+
+    if (existing) {
+      const embeddingVector = await embed(input.content);
+      const embeddingBuffer = embeddingToBuffer(embeddingVector);
+
+      updateMemoryContent(existing.id, {
+        content: input.content,
+        category: input.category,
+        metadata_json: input.metadata
+          ? JSON.stringify(input.metadata)
+          : undefined,
+        embedding: embeddingBuffer,
+      });
+
+      logMetric({
+        session_id: input.session_id,
+        event: "upsert",
+        memory_id: existing.id,
+      });
+
+      const output: RememberOutput = { id: existing.id, status: "updated" };
+
+      if (config.features.idempotency) {
+        saveIdempotencyResult(
+          input.idempotency_key,
+          "remember",
+          scopeIdForIdempotency,
+          { id: existing.id },
+        );
+      }
+
+      return output;
+    }
+
+    // No existing memory found — fall through to create path
+  }
+
+  // Non-upsert idempotency replay: return cached result if key matches
+  if (!input.upsert && config.features.idempotency && input.idempotency_key) {
+    const cached = getIdempotencyResult<{ id: string }>(
       input.idempotency_key,
       "remember",
       scopeIdForIdempotency,
     );
-    if (existing) {
-      return existing;
+    if (cached) {
+      return { id: cached.id, status: "created" };
     }
   }
 
+  // Create path
   const id = crypto.randomUUID();
 
-  // Generate embedding for semantic search
   const embeddingVector = await embed(input.content);
   const embeddingBuffer = embeddingToBuffer(embeddingVector);
 
@@ -56,27 +107,27 @@ export async function remember(input: RememberInput): Promise<RememberOutput> {
     thread_id: config.features.scopes ? input.thread_id : undefined,
     task_id: config.features.scopes ? input.task_id : undefined,
     metadata_json: input.metadata ? JSON.stringify(input.metadata) : undefined,
-    idempotency_key: config.features.idempotency
-      ? input.idempotency_key
-      : undefined,
+    idempotency_key:
+      config.features.idempotency || input.upsert
+        ? input.idempotency_key
+        : undefined,
     embedding: embeddingBuffer,
   });
 
-  // Log metric
   logMetric({
     session_id: input.session_id,
     event: "remember",
     memory_id: id,
   });
 
-  const output = { id };
+  const output: RememberOutput = { id, status: "created" };
 
   if (config.features.idempotency && input.idempotency_key) {
     saveIdempotencyResult(
       input.idempotency_key,
       "remember",
       scopeIdForIdempotency,
-      output,
+      { id },
     );
   }
 

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -85,4 +85,22 @@ describe("http server", () => {
       server.stop();
     }
   });
+
+  test("remember returns 400 when upsert is true without idempotency_key", async () => {
+    const server = startHttpServer();
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${server.port}/remember`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content: "test", upsert: true }),
+      });
+
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("upsert requires idempotency_key");
+    } finally {
+      server.stop();
+    }
+  });
 });

--- a/test/remember.test.ts
+++ b/test/remember.test.ts
@@ -136,4 +136,221 @@ describe("remember tool", () => {
 
     expect(first.id).not.toBe(second.id);
   });
+
+  describe("upsert", () => {
+    test("creates memory when no existing match", async () => {
+      process.env.ENGRAM_ENABLE_IDEMPOTENCY = "1";
+
+      const result = await remember({
+        content: "New topic summary",
+        category: "fact",
+        idempotency_key: "topic-summary:onboarding",
+        upsert: true,
+      });
+
+      expect(result.status).toBe("created");
+      expect(result.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
+
+      const stored = getMemoryById(result.id);
+      expect(stored).not.toBeNull();
+      expect(stored!.content).toBe("New topic summary");
+      expect(stored!.category).toBe("fact");
+    });
+
+    test("updates existing memory when idempotency key matches", async () => {
+      process.env.ENGRAM_ENABLE_IDEMPOTENCY = "1";
+
+      const created = await remember({
+        content: "Original summary",
+        category: "fact",
+        metadata: { version: 1 },
+        idempotency_key: "topic-summary:onboarding",
+        upsert: true,
+      });
+
+      const updated = await remember({
+        content: "Updated summary",
+        category: "decision",
+        metadata: { version: 2 },
+        idempotency_key: "topic-summary:onboarding",
+        upsert: true,
+      });
+
+      expect(updated.status).toBe("updated");
+      expect(updated.id).toBe(created.id);
+
+      const stored = getMemoryById(created.id);
+      expect(stored!.content).toBe("Updated summary");
+      expect(stored!.category).toBe("decision");
+      expect(stored!.metadata_json).toBe('{"version":2}');
+    });
+
+    test("does not match keys across different scopes", async () => {
+      process.env.ENGRAM_ENABLE_IDEMPOTENCY = "1";
+      process.env.ENGRAM_ENABLE_SCOPES = "1";
+
+      const first = await remember({
+        content: "Scope A summary",
+        scope_id: "scope-a",
+        idempotency_key: "topic-summary:shared",
+        upsert: true,
+      });
+
+      const second = await remember({
+        content: "Scope B summary",
+        scope_id: "scope-b",
+        idempotency_key: "topic-summary:shared",
+        upsert: true,
+      });
+
+      expect(first.status).toBe("created");
+      expect(second.status).toBe("created");
+      expect(first.id).not.toBe(second.id);
+    });
+
+    test("throws when upsert is true but idempotency_key is missing", async () => {
+      await expect(
+        remember({ content: "No key", upsert: true }),
+      ).rejects.toThrow("upsert requires idempotency_key");
+    });
+
+    test("preserves created_at, access_count, strength after update", async () => {
+      process.env.ENGRAM_ENABLE_IDEMPOTENCY = "1";
+
+      const created = await remember({
+        content: "Original",
+        idempotency_key: "topic-summary:preserve",
+        upsert: true,
+      });
+
+      const beforeUpdate = getMemoryById(created.id)!;
+
+      // Small delay to ensure updated_at differs
+      await new Promise((resolve) => setTimeout(resolve, 1100));
+
+      await remember({
+        content: "Updated",
+        idempotency_key: "topic-summary:preserve",
+        upsert: true,
+      });
+
+      const afterUpdate = getMemoryById(created.id)!;
+
+      expect(afterUpdate.created_at).toBe(beforeUpdate.created_at);
+      expect(afterUpdate.access_count).toBe(beforeUpdate.access_count);
+      expect(afterUpdate.strength).toBe(beforeUpdate.strength);
+      expect(afterUpdate.updated_at).not.toBe(beforeUpdate.updated_at);
+    });
+
+    test("nulls omitted optional fields on update (full replace)", async () => {
+      process.env.ENGRAM_ENABLE_IDEMPOTENCY = "1";
+
+      const created = await remember({
+        content: "With metadata",
+        category: "fact",
+        metadata: { source: "test" },
+        idempotency_key: "topic-summary:replace",
+        upsert: true,
+      });
+
+      const beforeUpdate = getMemoryById(created.id)!;
+      expect(beforeUpdate.category).toBe("fact");
+      expect(beforeUpdate.metadata_json).toBe('{"source":"test"}');
+
+      await remember({
+        content: "Without metadata",
+        idempotency_key: "topic-summary:replace",
+        upsert: true,
+      });
+
+      const afterUpdate = getMemoryById(created.id)!;
+      expect(afterUpdate.content).toBe("Without metadata");
+      expect(afterUpdate.category).toBeNull();
+      expect(afterUpdate.metadata_json).toBeNull();
+    });
+
+    test("upsert works even when idempotency feature flag is disabled", async () => {
+      // ENGRAM_ENABLE_IDEMPOTENCY is "0" from beforeEach
+      const created = await remember({
+        content: "Original",
+        category: "fact",
+        idempotency_key: "topic-summary:no-flag",
+        upsert: true,
+      });
+
+      expect(created.status).toBe("created");
+
+      const updated = await remember({
+        content: "Updated",
+        category: "decision",
+        idempotency_key: "topic-summary:no-flag",
+        upsert: true,
+      });
+
+      expect(updated.status).toBe("updated");
+      expect(updated.id).toBe(created.id);
+
+      const stored = getMemoryById(created.id)!;
+      expect(stored.content).toBe("Updated");
+    });
+
+    test("non-upsert idempotency replay is unchanged and returns status created", async () => {
+      process.env.ENGRAM_ENABLE_IDEMPOTENCY = "1";
+
+      const first = await remember({
+        content: "Idempotent memory",
+        idempotency_key: "replay-key",
+      });
+
+      const replayed = await remember({
+        content: "Idempotent memory",
+        idempotency_key: "replay-key",
+      });
+
+      expect(first.status).toBe("created");
+      expect(replayed.status).toBe("created");
+      expect(replayed.id).toBe(first.id);
+
+      // Content should not have changed
+      const stored = getMemoryById(first.id);
+      expect(stored!.content).toBe("Idempotent memory");
+    });
+
+    test("regular remember without key returns status created", async () => {
+      const result = await remember({ content: "Simple memory" });
+
+      expect(result.status).toBe("created");
+    });
+
+    test("non-upsert replay returns status created after prior upsert update", async () => {
+      process.env.ENGRAM_ENABLE_IDEMPOTENCY = "1";
+
+      // Create via upsert
+      const created = await remember({
+        content: "Version 1",
+        idempotency_key: "ledger-test",
+        upsert: true,
+      });
+      expect(created.status).toBe("created");
+
+      // Update via upsert
+      const updated = await remember({
+        content: "Version 2",
+        idempotency_key: "ledger-test",
+        upsert: true,
+      });
+      expect(updated.status).toBe("updated");
+      expect(updated.id).toBe(created.id);
+
+      // Replay via non-upsert — should return "created", not "updated"
+      const replayed = await remember({
+        content: "Version 2",
+        idempotency_key: "ledger-test",
+      });
+      expect(replayed.status).toBe("created");
+      expect(replayed.id).toBe(created.id);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Add `upsert: true` option to `POST /remember` that overwrites an existing memory matched by `idempotency_key` + `scope_id` instead of creating a duplicate
- Uses full-replace semantics: `content`, `category`, `metadata`, and `embedding` are overwritten; `created_at`, `access_count`, `strength`, and scope fields are preserved
- Response contract changed to `{ id, status: "created" | "updated" }` on all paths (including non-upsert)
- Includes `[minor]` marker for v0.2.0 release bump

## Changes

| File | What |
|---|---|
| `src/db/index.ts` | `findMemoryByIdempotencyKey()`, `updateMemoryContent()`, `"upsert"` metric event |
| `src/tools/remember.ts` | Upsert path (bypasses idempotency replay), `status` field, stores key even when idempotency flag is off |
| `src/index.ts` | MCP schema + validation for `upsert` |
| `src/http.ts` | HTTP 400 validation for `upsert` without `idempotency_key` |
| `test/remember.test.ts` | 10 new tests: create, update, scope isolation, validation, preserved fields, full-replace nulling, flag-disabled edge case, replay behavior, ledger consistency |
| `test/http.test.ts` | 1 new test: HTTP 400 for upsert without key |
| `README.md` | Updated `remember` tool docs with upsert behavior |

## Testing

105/105 tests pass (`bun run validate:full`). Two review passes completed with all findings addressed.

## Bug found during review

The review caught that upsert silently degenerates into repeated creates when `ENGRAM_ENABLE_IDEMPOTENCY=0` because the `idempotency_key` wasn't being stored on the memory row. Fixed by storing the key when `input.upsert` is true regardless of the flag. Regression test added.

Closes #15