### PR TITLE
refactor: standardize daemon paths to ~/.config/engram/

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -85,7 +85,3 @@ export function getConfig(): Config {
     },
   };
 }
-
-export function getDataDirectory(): string {
-  return getDataDir();
-}


### PR DESCRIPTION
## Summary
- Move daemon pid+log files from `~/.local/share/engram/` to `~/.config/engram/`
- Standardizes daemon artifact location across all Wilson-managed services (engram, synapse, cortex all now use `~/.config/<name>/`)
- SQLite database remains in `~/.local/share/engram/` (XDG-correct for app data)
- Remove dead `getDataDirectory()` export from config.ts

## Migration
On the Mac Mini, the old log at `~/.local/share/engram/engram.log` and pid file will be orphaned after deploy. Harmless — just stale files.