### PR TITLE
fix: update core to v0.1.16

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -135,7 +135,7 @@
 
     "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
 
-    "@shetty4l/core": ["@shetty4l/core@0.1.15", "", { "bin": { "version-bump": "bin/version-bump.js" } }, "sha512-hb87wA6jLCtsNT7jt4Iihjj8JPaq+zATxiS4AiXw7OW5YVdQVPwQn3/ZOu0dKo9b49SaD54wYvxMOoo96nH9MA=="],
+    "@shetty4l/core": ["@shetty4l/core@0.1.16", "", { "bin": { "version-bump": "bin/version-bump.js" } }, "sha512-tiHDhTwYEXxliB89amQd+sJTtzyLmgIwJrT73IhR92gTRWTPkTO6OL1vVedpB+eL+2cd6+Zs5a2a2e/vE+UkYQ=="],
 
     "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 


### PR DESCRIPTION
## Summary

- Update `@shetty4l/core` to v0.1.16 which fixes `runCli` killing long-running serve commands via premature `process.exit()`
- This caused engram daemon startup to fail on the Mac Mini