### PR TITLE
fix: FTS5 query escaping and add operational logging

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@shetty4l/core": ">=0.1.0 <1.0.0",
+        "@shetty4l/core": "^0.1.18",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.3.13",
@@ -135,7 +135,7 @@
 
     "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
 
-    "@shetty4l/core": ["@shetty4l/core@0.1.17", "", { "bin": { "version-bump": "bin/version-bump.js" } }, "sha512-OkgMYxF5273YTMqNMiE+LDix33ESrP9MI8XeNbTDEHBPc+0Gf5CrUgV/dmPIggjiAUT+zLLO/Asdb2o262lrgQ=="],
+    "@shetty4l/core": ["@shetty4l/core@0.1.18", "", { "bin": { "version-bump": "bin/version-bump.js" } }, "sha512-lMZ//FvhD6Uu8bWM75fwPd6A412zrZp3CPXxlNeFZr6VtiVh9Ua+LqkrBm7t4CDUrXDOr+AezpR+xfvkCThnAA=="],
 
     "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@
  *   engram stop            Stop daemon
  *   engram status          Show daemon status
  *   engram restart         Restart daemon
+ *   engram logs [n]        Show last n log lines (default: 20)
  *   engram version         Show version
  *
  * Options:
@@ -27,8 +28,10 @@
  */
 
 import type { CommandHandler } from "@shetty4l/core/cli";
-import { formatUptime, runCli } from "@shetty4l/core/cli";
+import { createLogsCommand, formatUptime, runCli } from "@shetty4l/core/cli";
+import { getConfigDir } from "@shetty4l/core/config";
 import { onShutdown } from "@shetty4l/core/signals";
+import { join } from "path";
 import { getConfig } from "./config";
 import {
   getDaemonStatus,
@@ -53,6 +56,9 @@ import { calculateDecayedStrength, daysSince } from "./db/decay";
 import { startHttpServer } from "./http";
 import { VERSION } from "./version";
 
+const CONFIG_DIR = getConfigDir("engram");
+const LOG_FILE = join(CONFIG_DIR, "engram.log");
+
 const HELP = `
 Engram CLI \u2014 persistent memory for AI agents
 
@@ -72,6 +78,7 @@ Usage:
   engram status          Show daemon status
   engram restart         Restart daemon
   engram health          Check health of running instance
+  engram logs [n]        Show last n log lines (default: 20)
   engram version         Show version
 
 Options:
@@ -544,6 +551,10 @@ runCli({
     status: cmdStatus,
     restart: () => cmdRestart(),
     health: cmdHealth,
+    logs: createLogsCommand({
+      logFile: LOG_FILE,
+      emptyMessage: "No log entries yet.",
+    }),
     stats: withDb(cmdStats),
     recent: withDb(cmdRecent),
     search: withDb(cmdSearch),


### PR DESCRIPTION
## Summary
- **db/index.ts**: Fix FTS5 crashes on queries with `?`, `.`, `-` — wrap in double quotes for literal phrase matching, add try/catch fallback to `getAllMemories` on parse error
- **http.ts**: per-request access log to stderr (method path status latencyMs), add version to startup banner
- **cli.ts**: add `logs` command via `createLogsCommand` from `@shetty4l/core@0.1.18`

Human-readable `engram:` prefix format. All operational logs go to stderr.