### PR TITLE
refactor: adopt core CLI command factories

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@shetty4l/core": ">=0.1.0 <1.0.0",
+        "@shetty4l/core": "^0.1.30",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.3.13",
@@ -157,7 +157,7 @@
 
     "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
 
-    "@shetty4l/core": ["@shetty4l/core@0.1.28", "", { "bin": { "version-bump": "bin/version-bump.js" } }, "sha512-Xe3QMu3mKoZmIziyNzQsP7CkkxNdYGz9dUwXwC7hkXFtAwhGOwi2KLr0svRLJgP6phUkZcXK01C+i65CcQyj/w=="],
+    "@shetty4l/core": ["@shetty4l/core@0.1.30", "", { "bin": { "version-bump": "bin/version-bump.js" } }, "sha512-Q0Po5lEHo7OlG0J+7mPYSoZmqvNvZr4dxnexrLXx/RZI/JnQcvBl4J7mE0luFZWdj3wsvZyDjWyMARMl6IiokA=="],
 
     "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@shetty4l/core": ">=0.1.0 <1.0.0"
+    "@shetty4l/core": "^0.1.30"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.13",


### PR DESCRIPTION
## Summary
- Replaces custom daemon lifecycle commands and health command with core's `createDaemonCommands` and `createHealthCommand` factories
- Bumps `@shetty4l/core` to v0.1.30

## Changes
- **`src/cli.ts`**: Replaced `cmdStart`/`cmdStop`/`cmdStatus`/`cmdRestart`/`cmdHealth` with factory calls. Spread `...daemonCmds` into commands map.

## Impact
- 19 insertions, 98 deletions (net **-79 lines**)
- All 59 tests pass, typecheck/lint/format clean

## Note
`parsePortEnv` replacement with core's `parsePort` deferred to a separate PR (low priority, needs minor API adjustment in core for port 0 support).