### PR TITLE
chore: suppress /stats endpoint from HTTP logs

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -56,7 +56,7 @@ export function startHttpServer(): HttpServer {
       const start = performance.now();
       const response = await routeRequest(req, url);
 
-      if (response) {
+      if (response && url.pathname !== "/stats") {
         const latency = (performance.now() - start).toFixed(0);
         log(`${req.method} ${url.pathname} ${response.status} ${latency}ms`);
       }


### PR DESCRIPTION
## Summary

- Skip logging for `/stats` endpoint requests to reduce log noise
- Dashboard polls `/stats` frequently, creating excessive log entries

## Related PRs

- shetty4l/cortex - same change
- shetty4l/synapse - same change