### PR TITLE
fix: scoped recall includes unscoped (NULL scope_id) memories

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -312,7 +312,7 @@ function applyMemoryFilters(
   params: Record<string, string | number>,
 ): void {
   if (filters.scope_id) {
-    clauses.push("scope_id = $scope_id");
+    clauses.push("(scope_id = $scope_id OR scope_id IS NULL)");
     params.$scope_id = filters.scope_id;
   }
   if (filters.chat_id) {

--- a/test/recall.test.ts
+++ b/test/recall.test.ts
@@ -152,6 +152,21 @@ describe("recall tool", () => {
     expect(result.memories[0].content).toBe("Project A memory");
   });
 
+  test("scoped recall includes unscoped (NULL scope_id) memories", async () => {
+    process.env.ENGRAM_ENABLE_SCOPES = "1";
+
+    await remember({ content: "Legacy unscoped memory" });
+    await remember({ content: "Scoped memory for agent", scope_id: "takumi" });
+    await remember({ content: "Other agent memory", scope_id: "wilson" });
+
+    const result = await recall({ query: "memory", scope_id: "takumi" });
+
+    const contents = result.memories.map((m) => m.content);
+    expect(contents).toContain("Legacy unscoped memory");
+    expect(contents).toContain("Scoped memory for agent");
+    expect(contents).not.toContain("Other agent memory");
+  });
+
   // Semantic search behavior tests
   describe("semantic search", () => {
     test("finds memories with semantically similar content", async () => {


### PR DESCRIPTION
## Summary

- Scoped recall previously used strict equality (`scope_id = $scope_id`), which silently excluded all legacy memories with `NULL` scope_id
- Changed to `(scope_id = $scope_id OR scope_id IS NULL)` so agents using scopes retain access to the existing unscoped memory pool
- Added test covering the NULL scope_id inclusion behavior

Resolves the open question in `docs/specs/2026-02-multi-agent-compat-primitives.md`:
> Should `scope_id` default to an explicit value (`global`) in storage, or remain null for legacy rows?

Answer: remain null. Unscoped memories are visible to all scoped queries — they belong to everyone.