### PR TITLE
feat: export/import sync for cross-machine memory sharing

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "bun run src/index.ts",
     "analyze": "bun run src/cli.ts",
     "opencode:config": "bun run scripts/opencode-config.ts",
-    "test:core": "bun test test/db.test.ts test/cli.test.ts test/capabilities.test.ts test/http.test.ts test/decay.test.ts test/stats.test.ts",
+    "test:core": "bun test test/db.test.ts test/cli.test.ts test/capabilities.test.ts test/http.test.ts test/decay.test.ts test/stats.test.ts test/sync.test.ts",
     "test:full": "bun test",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint src/",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@
  *   engram prune [opts]    Delete weak memories (--threshold=0.1 --dry-run)
  *   engram export [opts]   Export memories as NDJSON (--output=<file> --no-embeddings)
  *   engram import <file|-> Import memories from NDJSON (--dry-run --reembed --similarity=0.92)
+ *   engram sync <url>      Bidirectional sync with remote instance (--dry-run --similarity=0.92)
  *
  *   engram serve           Start HTTP server (foreground)
  *   engram start           Start HTTP server as daemon
@@ -57,7 +58,11 @@ import {
 } from "./db";
 import { calculateDecayedStrength, daysSince } from "./db/decay";
 import { startHttpServer } from "./http";
-import { exportMemoriesNDJSON, importMemories } from "./sync";
+import {
+  exportMemoriesNDJSON,
+  type ImportResult,
+  importMemories,
+} from "./sync";
 import { VERSION } from "./version";
 
 const CONFIG_DIR = getConfigDir("engram");
@@ -77,6 +82,7 @@ Usage:
   engram prune [opts]    Delete weak memories (--threshold=0.1 --dry-run)
   engram export [opts]   Export memories as NDJSON (--output=<file> --no-embeddings)
   engram import <file|-> Import memories from NDJSON (--dry-run --reembed --similarity=0.92)
+  engram sync <url>      Bidirectional sync with remote (--dry-run --similarity=0.92)
 
   engram serve           Start HTTP server (foreground)
   engram start           Start HTTP server as daemon
@@ -568,6 +574,126 @@ async function cmdImport(args: string[], json: boolean): Promise<number> {
   return 0;
 }
 
+async function cmdSync(args: string[], json: boolean): Promise<number> {
+  const positionalArgs = args.filter((a) => !a.startsWith("--"));
+  const url = positionalArgs[0];
+
+  if (!url) {
+    console.error("Error: remote URL required");
+    console.error("Usage: engram sync <url> [--dry-run] [--similarity=0.92]");
+    return 1;
+  }
+
+  const dryRun = args.includes("--dry-run");
+  const similarityArg = args.find((a) => a.startsWith("--similarity="));
+  const similarityThreshold = similarityArg
+    ? Number.parseFloat(similarityArg.split("=")[1])
+    : 0.92;
+
+  if (
+    Number.isNaN(similarityThreshold) ||
+    similarityThreshold < 0 ||
+    similarityThreshold > 1
+  ) {
+    console.error("Error: similarity must be a number between 0 and 1");
+    return 1;
+  }
+
+  const baseUrl = url.replace(/\/+$/, "");
+
+  // 1. Pull: Fetch remote export → import locally
+  const exportUrl = `${baseUrl}/export`;
+  let pullResult: ImportResult;
+
+  try {
+    const res = await fetch(exportUrl);
+    if (!res.ok) {
+      console.error(
+        `Error: GET ${exportUrl} returned ${res.status} ${res.statusText}`,
+      );
+      return 1;
+    }
+    const body = await res.text();
+    const lines = body.split("\n").filter((l) => l.trim());
+    pullResult = await importMemories(lines, {
+      dryRun,
+      reembed: false,
+      similarityThreshold,
+    });
+  } catch (e) {
+    console.error(
+      `Error: failed to fetch from ${exportUrl} — ${e instanceof Error ? e.message : String(e)}`,
+    );
+    return 1;
+  }
+
+  // 2. Push: Stream local export → remote import
+  const importParams = new URLSearchParams();
+  if (dryRun) importParams.set("dry_run", "1");
+  importParams.set("similarity", String(similarityThreshold));
+  const importUrl = `${baseUrl}/import?${importParams.toString()}`;
+
+  let pushResult: ImportResult;
+  try {
+    const ndjsonLines: string[] = [];
+    for (const line of exportMemoriesNDJSON({ includeEmbeddings: true })) {
+      ndjsonLines.push(line);
+    }
+    const body = `${ndjsonLines.join("\n")}\n`;
+
+    const res = await fetch(importUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-ndjson" },
+      body,
+    });
+    if (!res.ok) {
+      console.error(
+        `Error: POST ${importUrl} returned ${res.status} ${res.statusText}`,
+      );
+      return 1;
+    }
+    pushResult = (await res.json()) as ImportResult;
+  } catch (e) {
+    console.error(
+      `Error: failed to push to ${importUrl} — ${e instanceof Error ? e.message : String(e)}`,
+    );
+    return 1;
+  }
+
+  // 3. Report combined results
+  if (json) {
+    console.log(
+      JSON.stringify(
+        {
+          dry_run: dryRun,
+          pull: pullResult,
+          push: pushResult,
+        },
+        null,
+        2,
+      ),
+    );
+    return 0;
+  }
+
+  const label = dryRun ? "=== Sync Dry Run ===" : "=== Sync Complete ===";
+  console.log(label);
+  console.log("  Pull (remote → local):");
+  console.log(`    Inserted:          ${pullResult.inserted}`);
+  console.log(`    Skipped duplicate: ${pullResult.skippedDuplicate}`);
+  console.log(
+    `    Conflicts:         local wins: ${pullResult.resolved.localWins}, remote wins: ${pullResult.resolved.remoteWins}`,
+  );
+  console.log("  Push (local → remote):");
+  console.log(`    Inserted:          ${pushResult.inserted}`);
+  console.log(`    Skipped duplicate: ${pushResult.skippedDuplicate}`);
+  console.log(
+    `    Conflicts:         local wins: ${pushResult.resolved.localWins}, remote wins: ${pushResult.resolved.remoteWins}`,
+  );
+
+  return 0;
+}
+
 function cmdConfig(_args: string[], json: boolean): void {
   const result = loadConfig();
   if (!result.ok) {
@@ -649,5 +775,6 @@ runCli({
     prune: withDb(cmdPrune),
     export: withDb(cmdExport),
     import: withDb(cmdImport),
+    sync: withDb(cmdSync),
   },
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,8 @@
  *   engram forget <id>     Delete a specific memory
  *   engram decay           Show decay status for all memories
  *   engram prune [opts]    Delete weak memories (--threshold=0.1 --dry-run)
+ *   engram export [opts]   Export memories as NDJSON (--output=<file> --no-embeddings)
+ *   engram import <file|-> Import memories from NDJSON (--dry-run --reembed --similarity=0.92)
  *
  *   engram serve           Start HTTP server (foreground)
  *   engram start           Start HTTP server as daemon
@@ -36,6 +38,7 @@ import {
 } from "@shetty4l/core/cli";
 import { getConfigDir } from "@shetty4l/core/config";
 import { onShutdown } from "@shetty4l/core/signals";
+import { readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import { getConfig, loadConfig } from "./config";
 import { getDaemon } from "./daemon";
@@ -54,6 +57,7 @@ import {
 } from "./db";
 import { calculateDecayedStrength, daysSince } from "./db/decay";
 import { startHttpServer } from "./http";
+import { exportMemoriesNDJSON, importMemories } from "./sync";
 import { VERSION } from "./version";
 
 const CONFIG_DIR = getConfigDir("engram");
@@ -71,6 +75,8 @@ Usage:
   engram forget <id>     Delete a specific memory
   engram decay           Show decay status for all memories
   engram prune [opts]    Delete weak memories (--threshold=0.1 --dry-run)
+  engram export [opts]   Export memories as NDJSON (--output=<file> --no-embeddings)
+  engram import <file|-> Import memories from NDJSON (--dry-run --reembed --similarity=0.92)
 
   engram serve           Start HTTP server (foreground)
   engram start           Start HTTP server as daemon
@@ -463,6 +469,105 @@ function cmdPrune(args: string[], json: boolean): number {
   return 0;
 }
 
+function cmdExport(args: string[], _json: boolean): number {
+  const noEmbeddings = args.includes("--no-embeddings");
+  const outputArg = args.find((a) => a.startsWith("--output="));
+  const outputFile = outputArg ? outputArg.split("=")[1] : null;
+
+  let count = 0;
+  const lines: string[] = [];
+
+  for (const line of exportMemoriesNDJSON({
+    includeEmbeddings: !noEmbeddings,
+  })) {
+    if (outputFile) {
+      lines.push(line);
+    } else {
+      console.log(line);
+    }
+    count++;
+  }
+
+  if (outputFile) {
+    writeFileSync(outputFile, `${lines.join("\n")}\n`);
+  }
+
+  console.error(`exported ${count} memories`);
+  return 0;
+}
+
+async function cmdImport(args: string[], json: boolean): Promise<number> {
+  const positionalArgs = args.filter((a) => !a.startsWith("--"));
+  const filePath = positionalArgs[0];
+
+  if (!filePath) {
+    console.error("Error: file path or '-' for stdin required");
+    console.error(
+      "Usage: engram import <file|-> [--dry-run] [--reembed] [--similarity=0.92]",
+    );
+    return 1;
+  }
+
+  const dryRun = args.includes("--dry-run");
+  const reembed = args.includes("--reembed");
+  const similarityArg = args.find((a) => a.startsWith("--similarity="));
+  const similarityThreshold = similarityArg
+    ? Number.parseFloat(similarityArg.split("=")[1])
+    : 0.92;
+
+  if (
+    Number.isNaN(similarityThreshold) ||
+    similarityThreshold < 0 ||
+    similarityThreshold > 1
+  ) {
+    console.error("Error: similarity must be a number between 0 and 1");
+    return 1;
+  }
+
+  // Read input: file or stdin
+  let content: string;
+  if (filePath === "-") {
+    // Read from stdin (Bun.stdin is a ReadableStream, but we need sync for CLI)
+    const buf = readFileSync("/dev/stdin", "utf-8");
+    content = buf;
+  } else {
+    try {
+      content = readFileSync(filePath, "utf-8");
+    } catch (e) {
+      console.error(
+        `Error: cannot read file: ${filePath} — ${e instanceof Error ? e.message : String(e)}`,
+      );
+      return 1;
+    }
+  }
+
+  const lines = content.split("\n").filter((l) => l.trim());
+
+  const result = await importMemories(lines, {
+    dryRun,
+    reembed,
+    similarityThreshold,
+  });
+
+  if (json) {
+    console.log(JSON.stringify({ ...result, dry_run: dryRun }, null, 2));
+    return 0;
+  }
+
+  if (dryRun) {
+    console.log("=== Import Dry Run ===");
+  } else {
+    console.log("=== Import Complete ===");
+  }
+  console.log(`  Inserted:          ${result.inserted}`);
+  console.log(`  Skipped duplicate: ${result.skippedDuplicate}`);
+  console.log(
+    `  Conflicts:         local wins: ${result.resolved.localWins}, remote wins: ${result.resolved.remoteWins}`,
+  );
+
+  return 0;
+}
+
 function cmdConfig(_args: string[], json: boolean): void {
   const result = loadConfig();
   if (!result.ok) {
@@ -542,5 +647,7 @@ runCli({
     forget: withDb(cmdForget),
     decay: withDb(cmdDecay),
     prune: withDb(cmdPrune),
+    export: withDb(cmdExport),
+    import: withDb(cmdImport),
   },
 });

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -913,3 +913,79 @@ export function getStatsForApi(): ApiStats {
     },
   };
 }
+
+// Sync/export-import functions
+
+/**
+ * Iterate over all memories in the database.
+ * Wraps stmt.all() as a generator for interface consistency
+ * and to allow future cursor-based streaming.
+ */
+export function* getAllMemoriesIterator(): Generator<Memory> {
+  const database = getDatabase();
+  const rows = database
+    .prepare("SELECT * FROM memories ORDER BY created_at ASC")
+    .all() as Memory[];
+  for (const row of rows) {
+    yield row;
+  }
+}
+
+export interface InsertMemoryRawInput {
+  id: string;
+  content: string;
+  category: string | null;
+  scope_id: string | null;
+  chat_id: string | null;
+  thread_id: string | null;
+  task_id: string | null;
+  metadata_json: string | null;
+  idempotency_key: string | null;
+  created_at: string;
+  updated_at: string;
+  last_accessed: string;
+  access_count: number;
+  strength: number;
+  embedding: Buffer | null;
+}
+
+/**
+ * Insert a memory preserving all original fields (id, timestamps, strength, access_count).
+ * Uses INSERT OR REPLACE to handle both new inserts and conflict resolution.
+ * Unlike createMemory(), this does not auto-generate id or timestamps.
+ * FTS triggers fire automatically on INSERT/REPLACE.
+ */
+export function insertMemoryRaw(input: InsertMemoryRawInput): Memory {
+  const database = getDatabase();
+  const stmt = database.prepare(`
+    INSERT OR REPLACE INTO memories (
+      id, content, category, scope_id, chat_id, thread_id, task_id,
+      metadata_json, idempotency_key, created_at, updated_at,
+      last_accessed, access_count, strength, embedding
+    )
+    VALUES (
+      $id, $content, $category, $scope_id, $chat_id, $thread_id, $task_id,
+      $metadata_json, $idempotency_key, $created_at, $updated_at,
+      $last_accessed, $access_count, $strength, $embedding
+    )
+    RETURNING *
+  `);
+
+  return stmt.get({
+    $id: input.id,
+    $content: input.content,
+    $category: input.category,
+    $scope_id: input.scope_id,
+    $chat_id: input.chat_id,
+    $thread_id: input.thread_id,
+    $task_id: input.task_id,
+    $metadata_json: input.metadata_json,
+    $idempotency_key: input.idempotency_key,
+    $created_at: input.created_at,
+    $updated_at: input.updated_at,
+    $last_accessed: input.last_accessed,
+    $access_count: input.access_count,
+    $strength: input.strength,
+    $embedding: input.embedding,
+  }) as Memory;
+}

--- a/src/http.ts
+++ b/src/http.ts
@@ -6,6 +6,8 @@
  * - POST /recall - Retrieve memories
  * - POST /forget - Delete a memory by ID
  * - POST /context/hydrate - Hydrate assistant context (feature-flagged)
+ * - GET /export - Stream all memories as NDJSON
+ * - POST /import - Import memories from NDJSON body
  * - GET /capabilities - Feature discovery
  * - GET /health - Health check (handled by core)
  * - POST|DELETE /mcp - Streamable HTTP MCP transport (stateless)
@@ -24,6 +26,11 @@ import { getCapabilities } from "./capabilities";
 import { getConfig, logFeatureFlags } from "./config";
 import { getStatsForApi, initDatabase } from "./db";
 import { createMcpServer } from "./mcp-server";
+import {
+  exportMemoriesNDJSON,
+  type ImportResult,
+  importMemories,
+} from "./sync";
 import {
   type ContextHydrateInput,
   contextHydrate,
@@ -147,6 +154,60 @@ async function routeRequest(req: Request, url: URL): Promise<Response | null> {
 
     const result = await contextHydrate(bodyOrError);
     return jsonOk(result);
+  }
+
+  // Export endpoint — streams NDJSON
+  if (path === "/export" && method === "GET") {
+    const noEmbeddings = url.searchParams.get("no_embeddings") === "1";
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        for (const line of exportMemoriesNDJSON({
+          includeEmbeddings: !noEmbeddings,
+        })) {
+          controller.enqueue(encoder.encode(`${line}\n`));
+        }
+        controller.close();
+      },
+    });
+    return new Response(stream, {
+      status: 200,
+      headers: {
+        "Content-Type": "application/x-ndjson",
+        ...corsHeaders(),
+      },
+    });
+  }
+
+  // Import endpoint — accepts streaming NDJSON body
+  if (path === "/import" && method === "POST") {
+    const dryRun = url.searchParams.get("dry_run") === "1";
+    const reembed = url.searchParams.get("reembed") === "1";
+    const similarityParam = url.searchParams.get("similarity");
+    const similarityThreshold = similarityParam
+      ? Number.parseFloat(similarityParam)
+      : 0.92;
+
+    if (
+      Number.isNaN(similarityThreshold) ||
+      similarityThreshold < 0 ||
+      similarityThreshold > 1
+    ) {
+      return jsonError(400, "similarity must be a number between 0 and 1");
+    }
+
+    // Buffers the full body rather than streaming — conscious tradeoff for
+    // simplicity at current scale. Revisit if import payloads grow large.
+    const body = await req.text();
+    const lines = body.split("\n").filter((l) => l.trim());
+
+    const result: ImportResult = await importMemories(lines, {
+      dryRun,
+      reembed,
+      similarityThreshold,
+    });
+
+    return jsonOk({ ...result, dry_run: dryRun });
   }
 
   // Streamable HTTP MCP endpoint (stateless, per-request server)

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -11,7 +11,12 @@ import {
   getMemoryById,
   insertMemoryRaw,
 } from "./db";
-import { bufferToEmbedding, cosineSimilarity } from "./embedding";
+import {
+  bufferToEmbedding,
+  cosineSimilarity,
+  embed,
+  embeddingToBuffer,
+} from "./embedding";
 
 const log = createLogger("engram");
 
@@ -185,14 +190,14 @@ function isDuplicateByEmbedding(
  * - Unkeyed memories: dedup by embedding cosine similarity
  * - Exact ID matches: resolve by updated_at
  */
-export function importMemories(
+export async function importMemories(
   lines: Iterable<string>,
   opts: ImportOptions = {
     dryRun: false,
     reembed: false,
     similarityThreshold: 0.92,
   },
-): ImportResult {
+): Promise<ImportResult> {
   const result: ImportResult = {
     inserted: 0,
     skippedDuplicate: 0,
@@ -216,11 +221,20 @@ export function importMemories(
       continue;
     }
 
-    // Decode embedding if present and not re-embedding
-    const embeddingBuffer =
-      exported.embedding && !opts.reembed
-        ? decodeEmbedding(exported.embedding)
-        : null;
+    // Decode embedding if present and not re-embedding, or regenerate if reembed
+    let embeddingBuffer: Buffer | null = null;
+    if (opts.reembed) {
+      const embeddingResult = await embed(exported.content);
+      if (embeddingResult.ok) {
+        embeddingBuffer = embeddingToBuffer(embeddingResult.value);
+      } else {
+        log(
+          `warning: re-embedding failed for ${exported.id}, storing without vector — ${embeddingResult.error}`,
+        );
+      }
+    } else if (exported.embedding) {
+      embeddingBuffer = decodeEmbedding(exported.embedding);
+    }
 
     // 1. Check for exact ID match
     const existingById = getMemoryById(exported.id);

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1,0 +1,343 @@
+/**
+ * Sync module for export/import of memories across engram instances.
+ * Uses NDJSON format for streaming-friendly serialization.
+ */
+
+import { createLogger } from "@shetty4l/core/log";
+import type { Memory } from "./db";
+import {
+  findMemoryByIdempotencyKey,
+  getAllMemoriesIterator,
+  getMemoryById,
+  insertMemoryRaw,
+} from "./db";
+import { bufferToEmbedding, cosineSimilarity } from "./embedding";
+
+const log = createLogger("engram");
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+export interface ExportedMemory {
+  v: 1;
+  id: string;
+  content: string;
+  category: string | null;
+  scope_id: string | null;
+  chat_id: string | null;
+  thread_id: string | null;
+  task_id: string | null;
+  metadata_json: string | null;
+  idempotency_key: string | null;
+  created_at: string;
+  updated_at: string;
+  last_accessed: string;
+  access_count: number;
+  strength: number;
+  embedding: string | null; // base64-encoded Float32Array
+}
+
+export interface ImportResult {
+  inserted: number;
+  skippedDuplicate: number;
+  resolved: {
+    localWins: number;
+    remoteWins: number;
+  };
+}
+
+export interface ExportOptions {
+  includeEmbeddings: boolean;
+}
+
+export interface ImportOptions {
+  dryRun: boolean;
+  reembed: boolean;
+  similarityThreshold: number;
+}
+
+// ── NDJSON Helpers ─────────────────────────────────────────────────────
+
+/**
+ * Serialize a Memory row into an ExportedMemory JSON string (one NDJSON line).
+ */
+export function serializeMemory(
+  memory: Memory,
+  includeEmbeddings: boolean,
+): string {
+  const exported: ExportedMemory = {
+    v: 1,
+    id: memory.id,
+    content: memory.content,
+    category: memory.category,
+    scope_id: memory.scope_id,
+    chat_id: memory.chat_id,
+    thread_id: memory.thread_id,
+    task_id: memory.task_id,
+    metadata_json: memory.metadata_json,
+    idempotency_key: memory.idempotency_key,
+    created_at: memory.created_at,
+    updated_at: memory.updated_at,
+    last_accessed: memory.last_accessed,
+    access_count: memory.access_count,
+    strength: memory.strength,
+    embedding:
+      includeEmbeddings && memory.embedding
+        ? Buffer.from(
+            memory.embedding.buffer,
+            memory.embedding.byteOffset,
+            memory.embedding.byteLength,
+          ).toString("base64")
+        : null,
+  };
+  return JSON.stringify(exported);
+}
+
+/**
+ * Deserialize an NDJSON line into an ExportedMemory object.
+ * Throws on invalid JSON or missing required fields.
+ */
+export function deserializeMemory(line: string): ExportedMemory {
+  const parsed = JSON.parse(line) as ExportedMemory;
+  if (parsed.v !== 1) {
+    throw new Error(`unsupported export version: ${parsed.v}`);
+  }
+  if (!parsed.id || !parsed.content) {
+    throw new Error("missing required fields: id, content");
+  }
+  return parsed;
+}
+
+// ── Export ──────────────────────────────────────────────────────────────
+
+/**
+ * Export all memories as an async generator of ExportedMemory objects.
+ * Yields one memory at a time for streaming.
+ */
+export function* exportMemories(
+  opts: ExportOptions = { includeEmbeddings: true },
+): Generator<ExportedMemory> {
+  for (const memory of getAllMemoriesIterator()) {
+    const line = serializeMemory(memory, opts.includeEmbeddings);
+    yield JSON.parse(line) as ExportedMemory;
+  }
+}
+
+/**
+ * Export all memories as an async generator of NDJSON lines.
+ */
+export function* exportMemoriesNDJSON(
+  opts: ExportOptions = { includeEmbeddings: true },
+): Generator<string> {
+  for (const memory of getAllMemoriesIterator()) {
+    yield serializeMemory(memory, opts.includeEmbeddings);
+  }
+}
+
+// ── Import ─────────────────────────────────────────────────────────────
+
+/**
+ * Decode an ExportedMemory's base64 embedding back to a Buffer.
+ */
+function decodeEmbedding(base64: string): Buffer {
+  return Buffer.from(base64, "base64");
+}
+
+/**
+ * Resolve conflict between a local and remote memory sharing the same idempotency key.
+ * The memory with the latest `updated_at` wins.
+ * Returns "local" if local wins, "remote" if remote wins.
+ */
+export function resolveConflict(
+  local: Memory,
+  remote: ExportedMemory,
+): "local" | "remote" {
+  const localTime = new Date(local.updated_at).getTime();
+  const remoteTime = new Date(remote.updated_at).getTime();
+  // Remote wins only if strictly newer; ties go to local (keep existing)
+  return remoteTime > localTime ? "remote" : "local";
+}
+
+/**
+ * Check if an incoming unkeyed memory is a duplicate of any existing memory
+ * based on embedding cosine similarity.
+ */
+function isDuplicateByEmbedding(
+  incomingEmbedding: Buffer,
+  existingMemories: Array<{ embedding: Buffer | null }>,
+  threshold: number,
+): boolean {
+  const incoming = bufferToEmbedding(incomingEmbedding);
+  for (const existing of existingMemories) {
+    if (!existing.embedding) continue;
+    const existingEmb = bufferToEmbedding(existing.embedding);
+    const similarity = cosineSimilarity(incoming, existingEmb);
+    if (similarity >= threshold) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Import memories from an iterable of NDJSON lines.
+ * Performs conflict-aware merge:
+ * - Keyed memories (with idempotency_key): resolve by updated_at
+ * - Unkeyed memories: dedup by embedding cosine similarity
+ * - Exact ID matches: resolve by updated_at
+ */
+export function importMemories(
+  lines: Iterable<string>,
+  opts: ImportOptions = {
+    dryRun: false,
+    reembed: false,
+    similarityThreshold: 0.92,
+  },
+): ImportResult {
+  const result: ImportResult = {
+    inserted: 0,
+    skippedDuplicate: 0,
+    resolved: { localWins: 0, remoteWins: 0 },
+  };
+
+  // Collect existing memories with embeddings for similarity dedup (only if needed)
+  let existingEmbeddings: Array<{ embedding: Buffer | null }> | null = null;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    let exported: ExportedMemory;
+    try {
+      exported = deserializeMemory(trimmed);
+    } catch (e) {
+      log(
+        `warning: skipping invalid NDJSON line — ${e instanceof Error ? e.message : String(e)}`,
+      );
+      continue;
+    }
+
+    // Decode embedding if present and not re-embedding
+    const embeddingBuffer =
+      exported.embedding && !opts.reembed
+        ? decodeEmbedding(exported.embedding)
+        : null;
+
+    // 1. Check for exact ID match
+    const existingById = getMemoryById(exported.id);
+    if (existingById) {
+      const winner = resolveConflict(existingById, exported);
+      if (winner === "local") {
+        result.resolved.localWins++;
+        continue;
+      }
+      // Remote wins — update via raw insert (INSERT OR REPLACE)
+      if (!opts.dryRun) {
+        insertMemoryRaw({
+          id: exported.id,
+          content: exported.content,
+          category: exported.category,
+          scope_id: exported.scope_id,
+          chat_id: exported.chat_id,
+          thread_id: exported.thread_id,
+          task_id: exported.task_id,
+          metadata_json: exported.metadata_json,
+          idempotency_key: exported.idempotency_key,
+          created_at: exported.created_at,
+          updated_at: exported.updated_at,
+          last_accessed: exported.last_accessed,
+          access_count: exported.access_count,
+          strength: exported.strength,
+          embedding: embeddingBuffer,
+        });
+      }
+      result.resolved.remoteWins++;
+      continue;
+    }
+
+    // 2. Check for idempotency key match
+    if (exported.idempotency_key) {
+      const existingByKey = findMemoryByIdempotencyKey(
+        exported.idempotency_key,
+        exported.scope_id ?? undefined,
+      );
+      if (existingByKey) {
+        const winner = resolveConflict(existingByKey, exported);
+        if (winner === "local") {
+          result.resolved.localWins++;
+          continue;
+        }
+        // Remote wins — replace
+        if (!opts.dryRun) {
+          insertMemoryRaw({
+            id: existingByKey.id, // Keep local ID to avoid orphans
+            content: exported.content,
+            category: exported.category,
+            scope_id: exported.scope_id,
+            chat_id: exported.chat_id,
+            thread_id: exported.thread_id,
+            task_id: exported.task_id,
+            metadata_json: exported.metadata_json,
+            idempotency_key: exported.idempotency_key,
+            created_at: exported.created_at,
+            updated_at: exported.updated_at,
+            last_accessed: exported.last_accessed,
+            access_count: exported.access_count,
+            strength: exported.strength,
+            embedding: embeddingBuffer,
+          });
+        }
+        result.resolved.remoteWins++;
+        continue;
+      }
+    }
+
+    // 3. Unkeyed memory: check embedding similarity
+    if (!exported.idempotency_key && embeddingBuffer) {
+      // Lazily load existing embeddings
+      if (!existingEmbeddings) {
+        existingEmbeddings = [];
+        for (const m of getAllMemoriesIterator()) {
+          existingEmbeddings.push({ embedding: m.embedding });
+        }
+      }
+
+      if (
+        isDuplicateByEmbedding(
+          embeddingBuffer,
+          existingEmbeddings,
+          opts.similarityThreshold,
+        )
+      ) {
+        result.skippedDuplicate++;
+        continue;
+      }
+
+      // Not a duplicate — will be inserted. Add to existing embeddings for future checks within this batch.
+      existingEmbeddings.push({ embedding: embeddingBuffer });
+    }
+
+    // 4. Insert new memory
+    if (!opts.dryRun) {
+      insertMemoryRaw({
+        id: exported.id,
+        content: exported.content,
+        category: exported.category,
+        scope_id: exported.scope_id,
+        chat_id: exported.chat_id,
+        thread_id: exported.thread_id,
+        task_id: exported.task_id,
+        metadata_json: exported.metadata_json,
+        idempotency_key: exported.idempotency_key,
+        created_at: exported.created_at,
+        updated_at: exported.updated_at,
+        last_accessed: exported.last_accessed,
+        access_count: exported.access_count,
+        strength: exported.strength,
+        embedding: embeddingBuffer,
+      });
+    }
+    result.inserted++;
+  }
+
+  return result;
+}

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { closeDatabase, initDatabase, resetDatabase } from "../src/db";
+import {
+  closeDatabase,
+  createMemory,
+  initDatabase,
+  resetDatabase,
+} from "../src/db";
 import { startHttpServer } from "../src/http";
+import type { ExportedMemory } from "../src/sync";
 
 describe("http server", () => {
   const originalPort = process.env.ENGRAM_HTTP_PORT;
@@ -166,6 +172,145 @@ describe("http server", () => {
       expect(response.status).toBe(405);
       const body = (await response.json()) as { error: string };
       expect(body.error).toContain("Method not allowed");
+    } finally {
+      server.stop();
+    }
+  });
+
+  test("GET /export returns NDJSON with correct content-type", async () => {
+    // Seed some memories
+    createMemory({
+      id: "exp-1",
+      content: "Export test memory 1",
+      category: "fact",
+    });
+    createMemory({ id: "exp-2", content: "Export test memory 2" });
+
+    const server = startHttpServer();
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${server.port}/export`);
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Content-Type")).toBe("application/x-ndjson");
+
+      const body = await response.text();
+      const lines = body.split("\n").filter((l) => l.trim());
+      expect(lines).toHaveLength(2);
+
+      // Each line is valid JSON with v:1
+      for (const line of lines) {
+        const parsed = JSON.parse(line) as ExportedMemory;
+        expect(parsed.v).toBe(1);
+        expect(parsed.content).toBeDefined();
+      }
+    } finally {
+      server.stop();
+    }
+  });
+
+  test("POST /import with valid NDJSON returns summary", async () => {
+    const server = startHttpServer();
+
+    try {
+      const ndjson = [
+        JSON.stringify({
+          v: 1,
+          id: "imp-1",
+          content: "Imported 1",
+          category: null,
+          scope_id: null,
+          chat_id: null,
+          thread_id: null,
+          task_id: null,
+          metadata_json: null,
+          idempotency_key: null,
+          created_at: "2026-01-01 00:00:00",
+          updated_at: "2026-01-01 00:00:00",
+          last_accessed: "2026-01-01 00:00:00",
+          access_count: 1,
+          strength: 1.0,
+          embedding: null,
+        }),
+        JSON.stringify({
+          v: 1,
+          id: "imp-2",
+          content: "Imported 2",
+          category: null,
+          scope_id: null,
+          chat_id: null,
+          thread_id: null,
+          task_id: null,
+          metadata_json: null,
+          idempotency_key: null,
+          created_at: "2026-01-01 00:00:00",
+          updated_at: "2026-01-01 00:00:00",
+          last_accessed: "2026-01-01 00:00:00",
+          access_count: 1,
+          strength: 1.0,
+          embedding: null,
+        }),
+      ].join("\n");
+
+      const response = await fetch(`http://127.0.0.1:${server.port}/import`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-ndjson" },
+        body: ndjson,
+      });
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        inserted: number;
+        skippedDuplicate: number;
+        resolved: { localWins: number; remoteWins: number };
+        dry_run: boolean;
+      };
+      expect(body.inserted).toBe(2);
+      expect(body.skippedDuplicate).toBe(0);
+      expect(body.dry_run).toBe(false);
+    } finally {
+      server.stop();
+    }
+  });
+
+  test("POST /import?dry_run=1 returns preview without writing", async () => {
+    const server = startHttpServer();
+
+    try {
+      const ndjson = JSON.stringify({
+        v: 1,
+        id: "dry-1",
+        content: "Dry run memory",
+        category: null,
+        scope_id: null,
+        chat_id: null,
+        thread_id: null,
+        task_id: null,
+        metadata_json: null,
+        idempotency_key: null,
+        created_at: "2026-01-01 00:00:00",
+        updated_at: "2026-01-01 00:00:00",
+        last_accessed: "2026-01-01 00:00:00",
+        access_count: 1,
+        strength: 1.0,
+        embedding: null,
+      });
+
+      const response = await fetch(
+        `http://127.0.0.1:${server.port}/import?dry_run=1`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/x-ndjson" },
+          body: ndjson,
+        },
+      );
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        inserted: number;
+        dry_run: boolean;
+      };
+      expect(body.inserted).toBe(1);
+      expect(body.dry_run).toBe(true);
     } finally {
       server.stop();
     }

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -1,0 +1,460 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  closeDatabase,
+  countMemories,
+  createMemory,
+  getMemoryById,
+  initDatabase,
+  insertMemoryRaw,
+  resetDatabase,
+} from "../src/db";
+import { embeddingToBuffer } from "../src/embedding";
+import {
+  deserializeMemory,
+  type ExportedMemory,
+  exportMemories,
+  exportMemoriesNDJSON,
+  importMemories,
+  resolveConflict,
+  serializeMemory,
+} from "../src/sync";
+
+/** Create a fake normalized embedding (unit vector). */
+function fakeEmbedding(seed: number): Float32Array {
+  const dims = 384;
+  const emb = new Float32Array(dims);
+  for (let i = 0; i < dims; i++) {
+    emb[i] = Math.sin(seed * (i + 1));
+  }
+  // Normalize to unit vector
+  let norm = 0;
+  for (let i = 0; i < dims; i++) {
+    norm += emb[i] * emb[i];
+  }
+  norm = Math.sqrt(norm);
+  for (let i = 0; i < dims; i++) {
+    emb[i] /= norm;
+  }
+  return emb;
+}
+
+describe("sync", () => {
+  beforeEach(() => {
+    resetDatabase();
+    initDatabase(":memory:");
+  });
+
+  afterEach(() => {
+    closeDatabase();
+  });
+
+  describe("export", () => {
+    test("produces valid NDJSON with all fields", () => {
+      createMemory({
+        id: "mem-1",
+        content: "Test memory",
+        category: "fact",
+        scope_id: "scope-a",
+        idempotency_key: "key-1",
+        embedding: embeddingToBuffer(fakeEmbedding(1)),
+      });
+
+      const lines = [...exportMemoriesNDJSON({ includeEmbeddings: true })];
+      expect(lines).toHaveLength(1);
+
+      const parsed = deserializeMemory(lines[0]);
+      expect(parsed.v).toBe(1);
+      expect(parsed.id).toBe("mem-1");
+      expect(parsed.content).toBe("Test memory");
+      expect(parsed.category).toBe("fact");
+      expect(parsed.scope_id).toBe("scope-a");
+      expect(parsed.idempotency_key).toBe("key-1");
+      expect(parsed.created_at).toBeDefined();
+      expect(parsed.updated_at).toBeDefined();
+      expect(parsed.last_accessed).toBeDefined();
+      expect(parsed.access_count).toBe(1);
+      expect(parsed.strength).toBe(1.0);
+      expect(parsed.embedding).not.toBeNull();
+      // Verify embedding is valid base64
+      const buf = Buffer.from(parsed.embedding!, "base64");
+      expect(buf.byteLength).toBe(384 * 4); // Float32 = 4 bytes per element
+    });
+
+    test("with --no-embeddings omits embedding", () => {
+      createMemory({
+        id: "mem-1",
+        content: "Test memory",
+        embedding: embeddingToBuffer(fakeEmbedding(1)),
+      });
+
+      const lines = [...exportMemoriesNDJSON({ includeEmbeddings: false })];
+      expect(lines).toHaveLength(1);
+
+      const parsed = deserializeMemory(lines[0]);
+      expect(parsed.embedding).toBeNull();
+    });
+
+    test("exportMemories yields ExportedMemory objects", () => {
+      createMemory({ id: "mem-1", content: "First" });
+      createMemory({ id: "mem-2", content: "Second" });
+
+      const memories = [...exportMemories({ includeEmbeddings: false })];
+      expect(memories).toHaveLength(2);
+      expect(memories[0].v).toBe(1);
+      expect(memories[1].v).toBe(1);
+    });
+  });
+
+  describe("import", () => {
+    function makeNDJSONLine(overrides: Partial<ExportedMemory> = {}): string {
+      const mem: ExportedMemory = {
+        v: 1,
+        id: `import-${Math.random().toString(36).slice(2, 8)}`,
+        content: "Imported memory",
+        category: null,
+        scope_id: null,
+        chat_id: null,
+        thread_id: null,
+        task_id: null,
+        metadata_json: null,
+        idempotency_key: null,
+        created_at: "2026-01-01 00:00:00",
+        updated_at: "2026-01-01 00:00:00",
+        last_accessed: "2026-01-01 00:00:00",
+        access_count: 5,
+        strength: 0.8,
+        embedding: null,
+        ...overrides,
+      };
+      return JSON.stringify(mem);
+    }
+
+    test("import into empty DB inserts all memories", async () => {
+      const lines = [
+        makeNDJSONLine({ id: "a", content: "Alpha" }),
+        makeNDJSONLine({ id: "b", content: "Beta" }),
+        makeNDJSONLine({ id: "c", content: "Gamma" }),
+      ];
+
+      const result = await importMemories(lines, {
+        dryRun: false,
+        reembed: false,
+        similarityThreshold: 0.92,
+      });
+
+      expect(result.inserted).toBe(3);
+      expect(result.skippedDuplicate).toBe(0);
+      expect(result.resolved.localWins).toBe(0);
+      expect(result.resolved.remoteWins).toBe(0);
+      expect(countMemories()).toBe(3);
+    });
+
+    test("import with idempotency key conflict: latest updated_at wins", async () => {
+      // Create local memory with older timestamp
+      createMemory({
+        id: "local-1",
+        content: "Old local content",
+        idempotency_key: "shared-key",
+      });
+
+      // Import remote memory with same idempotency key but newer timestamp
+      const lines = [
+        makeNDJSONLine({
+          id: "remote-1",
+          content: "Newer remote content",
+          idempotency_key: "shared-key",
+          updated_at: "2099-01-01 00:00:00",
+        }),
+      ];
+
+      const result = await importMemories(lines, {
+        dryRun: false,
+        reembed: false,
+        similarityThreshold: 0.92,
+      });
+
+      expect(result.resolved.remoteWins).toBe(1);
+      expect(result.resolved.localWins).toBe(0);
+      // The local ID should be preserved (keeps local ID to avoid orphans)
+      const updated = getMemoryById("local-1");
+      expect(updated).not.toBeNull();
+      expect(updated!.content).toBe("Newer remote content");
+    });
+
+    test("import with idempotency key conflict: local newer → skip", async () => {
+      // Create local memory with newer timestamp
+      createMemory({
+        id: "local-1",
+        content: "Newer local content",
+        idempotency_key: "shared-key",
+      });
+
+      // Import remote memory with same idempotency key but older timestamp
+      const lines = [
+        makeNDJSONLine({
+          id: "remote-1",
+          content: "Older remote content",
+          idempotency_key: "shared-key",
+          updated_at: "2000-01-01 00:00:00",
+        }),
+      ];
+
+      const result = await importMemories(lines, {
+        dryRun: false,
+        reembed: false,
+        similarityThreshold: 0.92,
+      });
+
+      expect(result.resolved.localWins).toBe(1);
+      expect(result.resolved.remoteWins).toBe(0);
+      // Local content unchanged
+      const mem = getMemoryById("local-1");
+      expect(mem!.content).toBe("Newer local content");
+    });
+
+    test("import skips unkeyed memory when embedding similarity >= threshold", async () => {
+      const emb = fakeEmbedding(42);
+      createMemory({
+        id: "existing-1",
+        content: "Existing memory with embedding",
+        embedding: embeddingToBuffer(emb),
+      });
+
+      // Import with the exact same embedding — should be duplicate
+      const embBase64 = Buffer.from(
+        emb.buffer,
+        emb.byteOffset,
+        emb.byteLength,
+      ).toString("base64");
+
+      const lines = [
+        makeNDJSONLine({
+          id: "new-1",
+          content: "Should be detected as duplicate",
+          idempotency_key: null,
+          embedding: embBase64,
+        }),
+      ];
+
+      const result = await importMemories(lines, {
+        dryRun: false,
+        reembed: false,
+        similarityThreshold: 0.92,
+      });
+
+      expect(result.skippedDuplicate).toBe(1);
+      expect(result.inserted).toBe(0);
+      expect(countMemories()).toBe(1); // Only the original
+    });
+
+    test("import inserts unkeyed memory when no similar match exists", async () => {
+      const emb1 = fakeEmbedding(1);
+      createMemory({
+        id: "existing-1",
+        content: "Existing memory",
+        embedding: embeddingToBuffer(emb1),
+      });
+
+      // Import with a very different embedding
+      const emb2 = fakeEmbedding(9999);
+      const embBase64 = Buffer.from(
+        emb2.buffer,
+        emb2.byteOffset,
+        emb2.byteLength,
+      ).toString("base64");
+
+      const lines = [
+        makeNDJSONLine({
+          id: "new-1",
+          content: "Completely different memory",
+          idempotency_key: null,
+          embedding: embBase64,
+        }),
+      ];
+
+      const result = await importMemories(lines, {
+        dryRun: false,
+        reembed: false,
+        similarityThreshold: 0.92,
+      });
+
+      expect(result.inserted).toBe(1);
+      expect(result.skippedDuplicate).toBe(0);
+      expect(countMemories()).toBe(2);
+    });
+
+    test("import dry-run writes nothing but returns correct counts", async () => {
+      const lines = [
+        makeNDJSONLine({ id: "a", content: "Alpha" }),
+        makeNDJSONLine({ id: "b", content: "Beta" }),
+      ];
+
+      const result = await importMemories(lines, {
+        dryRun: true,
+        reembed: false,
+        similarityThreshold: 0.92,
+      });
+
+      expect(result.inserted).toBe(2);
+      expect(countMemories()).toBe(0); // Nothing written
+    });
+  });
+
+  describe("round-trip", () => {
+    test("export → import → same count and content", async () => {
+      // Populate source DB
+      createMemory({
+        id: "rt-1",
+        content: "Round-trip memory 1",
+        category: "fact",
+      });
+      createMemory({
+        id: "rt-2",
+        content: "Round-trip memory 2",
+        category: "decision",
+      });
+      createMemory({ id: "rt-3", content: "Round-trip memory 3" });
+
+      // Export
+      const lines = [...exportMemoriesNDJSON({ includeEmbeddings: true })];
+      expect(lines).toHaveLength(3);
+
+      // Re-init to a fresh empty DB
+      closeDatabase();
+      resetDatabase();
+      initDatabase(":memory:");
+      expect(countMemories()).toBe(0);
+
+      // Import
+      const result = await importMemories(lines, {
+        dryRun: false,
+        reembed: false,
+        similarityThreshold: 0.92,
+      });
+
+      expect(result.inserted).toBe(3);
+      expect(countMemories()).toBe(3);
+
+      // Verify content
+      const m1 = getMemoryById("rt-1");
+      expect(m1).not.toBeNull();
+      expect(m1!.content).toBe("Round-trip memory 1");
+      expect(m1!.category).toBe("fact");
+
+      const m2 = getMemoryById("rt-2");
+      expect(m2).not.toBeNull();
+      expect(m2!.content).toBe("Round-trip memory 2");
+      expect(m2!.category).toBe("decision");
+    });
+  });
+
+  describe("insertMemoryRaw", () => {
+    test("preserves all original fields", () => {
+      const raw = insertMemoryRaw({
+        id: "raw-1",
+        content: "Raw memory content",
+        category: "insight",
+        scope_id: "scope-x",
+        chat_id: "chat-1",
+        thread_id: "thread-1",
+        task_id: "task-1",
+        metadata_json: '{"key":"value"}',
+        idempotency_key: "idem-1",
+        created_at: "2020-06-15 12:00:00",
+        updated_at: "2021-03-20 08:30:00",
+        last_accessed: "2021-03-20 08:30:00",
+        access_count: 42,
+        strength: 0.75,
+        embedding: null,
+      });
+
+      expect(raw.id).toBe("raw-1");
+      expect(raw.content).toBe("Raw memory content");
+      expect(raw.category).toBe("insight");
+      expect(raw.scope_id).toBe("scope-x");
+      expect(raw.chat_id).toBe("chat-1");
+      expect(raw.thread_id).toBe("thread-1");
+      expect(raw.task_id).toBe("task-1");
+      expect(raw.metadata_json).toBe('{"key":"value"}');
+      expect(raw.idempotency_key).toBe("idem-1");
+      expect(raw.created_at).toBe("2020-06-15 12:00:00");
+      expect(raw.updated_at).toBe("2021-03-20 08:30:00");
+      expect(raw.last_accessed).toBe("2021-03-20 08:30:00");
+      expect(raw.access_count).toBe(42);
+      expect(raw.strength).toBe(0.75);
+
+      // Verify via getMemoryById too
+      const fetched = getMemoryById("raw-1");
+      expect(fetched).not.toBeNull();
+      expect(fetched!.access_count).toBe(42);
+      expect(fetched!.strength).toBe(0.75);
+      expect(fetched!.created_at).toBe("2020-06-15 12:00:00");
+    });
+  });
+
+  describe("resolveConflict", () => {
+    test("remote wins when remote is newer", () => {
+      const local = {
+        updated_at: "2025-01-01 00:00:00",
+      } as any;
+      const remote = {
+        updated_at: "2026-01-01 00:00:00",
+      } as ExportedMemory;
+
+      expect(resolveConflict(local, remote)).toBe("remote");
+    });
+
+    test("local wins when local is newer", () => {
+      const local = {
+        updated_at: "2026-01-01 00:00:00",
+      } as any;
+      const remote = {
+        updated_at: "2025-01-01 00:00:00",
+      } as ExportedMemory;
+
+      expect(resolveConflict(local, remote)).toBe("local");
+    });
+
+    test("local wins on tie", () => {
+      const ts = "2025-06-15 12:00:00";
+      const local = { updated_at: ts } as any;
+      const remote = { updated_at: ts } as ExportedMemory;
+
+      expect(resolveConflict(local, remote)).toBe("local");
+    });
+  });
+
+  describe("serializeMemory / deserializeMemory", () => {
+    test("round-trips correctly", () => {
+      createMemory({
+        id: "ser-1",
+        content: "Serialization test",
+        category: "fact",
+      });
+      const mem = getMemoryById("ser-1")!;
+
+      const line = serializeMemory(mem, false);
+      const parsed = deserializeMemory(line);
+
+      expect(parsed.id).toBe("ser-1");
+      expect(parsed.content).toBe("Serialization test");
+      expect(parsed.category).toBe("fact");
+      expect(parsed.v).toBe(1);
+      expect(parsed.embedding).toBeNull();
+    });
+
+    test("deserializeMemory throws on invalid version", () => {
+      const badLine = JSON.stringify({ v: 99, id: "x", content: "y" });
+      expect(() => deserializeMemory(badLine)).toThrow(
+        "unsupported export version",
+      );
+    });
+
+    test("deserializeMemory throws on missing fields", () => {
+      const badLine = JSON.stringify({ v: 1 });
+      expect(() => deserializeMemory(badLine)).toThrow(
+        "missing required fields",
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add core sync module with NDJSON export/import, conflict resolution by `updated_at`, and embedding similarity dedup for unkeyed memories
- Add CLI commands: `engram export`, `engram import`, and `engram sync <url>` for bidirectional sync
- Add HTTP endpoints: `GET /export` (streaming NDJSON) and `POST /import` (with dry-run support)

## Commits
1. `feat: core sync module and DB streaming support` — `src/sync.ts` (new), `src/db/index.ts` (modified)
2. `feat: CLI export and import commands` — `src/cli.ts` (modified)
3. `feat: HTTP export/import endpoints and sync command` — `src/http.ts`, `src/cli.ts` (modified)
4. `test: sync module and HTTP endpoint tests` — `test/sync.test.ts` (new), `test/http.test.ts` (modified)

## Validation
All checks pass: 97 tests, 293 assertions, 0 failures. Typecheck, lint, and format all clean.