### PR TITLE
feat(recall): recency-aware ranking + strict scope filtering

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -34,6 +34,21 @@ export interface Config {
     /** Strength to set when a memory is accessed */
     accessBoostStrength: number;
   };
+  recall: {
+    /**
+     * How much recency influences ranking, 0..1.
+     * Final score = relevance * (1 - recencyWeight) + recencyScore * recencyWeight.
+     * 0 = pure semantic similarity (legacy behavior).
+     * Higher values bias toward newer memories — useful for breaking ties
+     * between semantically near-identical memories (e.g. session indices).
+     */
+    recencyWeight: number;
+    /**
+     * Half-life in days for the recency score.
+     * A memory this many days old gets a recency score of 0.5.
+     */
+    recencyHalfLifeDays: number;
+  };
   http: {
     port: number;
     host: string;
@@ -41,6 +56,8 @@ export interface Config {
   embedding: {
     model: string;
     cacheDir: string;
+    /** Max time to wait for the model to load before falling back to FTS5. */
+    loadTimeoutMs: number;
   };
   features: {
     scopes: boolean;
@@ -72,10 +89,13 @@ interface ConfigFileSchema {
   dbPath?: string;
   embeddingModel?: string;
   embeddingCacheDir?: string;
+  embeddingLoadTimeoutMs?: number;
   decayRate?: number;
   accessBoostStrength?: number;
   defaultRecallLimit?: number;
   minStrength?: number;
+  recencyWeight?: number;
+  recencyHalfLifeDays?: number;
   scopes?: boolean;
   idempotency?: boolean;
   contextHydration?: boolean;
@@ -86,10 +106,13 @@ const FILE_DEFAULTS: ConfigFileSchema = {
   port: 7749,
   host: "127.0.0.1",
   embeddingModel: "Xenova/bge-small-en-v1.5",
+  embeddingLoadTimeoutMs: 60_000,
   decayRate: 0.95,
   accessBoostStrength: 1.0,
   defaultRecallLimit: 10,
   minStrength: 0.1,
+  recencyWeight: 0.2,
+  recencyHalfLifeDays: 14,
   scopes: true,
   idempotency: true,
   contextHydration: true,
@@ -187,6 +210,18 @@ export function loadConfig(configPath?: string): Result<ConfigLoadResult> {
         fileConfig.accessBoostStrength ?? 1.0,
       ),
     },
+    recall: {
+      recencyWeight: parseFloatEnv(
+        "ENGRAM_RECENCY_WEIGHT",
+        process.env.ENGRAM_RECENCY_WEIGHT,
+        fileConfig.recencyWeight ?? 0.2,
+      ),
+      recencyHalfLifeDays: parseFloatEnv(
+        "ENGRAM_RECENCY_HALF_LIFE_DAYS",
+        process.env.ENGRAM_RECENCY_HALF_LIFE_DAYS,
+        fileConfig.recencyHalfLifeDays ?? 14,
+      ),
+    },
     http: {
       port: parsePortEnv(
         "ENGRAM_HTTP_PORT",
@@ -203,6 +238,11 @@ export function loadConfig(configPath?: string): Result<ConfigLoadResult> {
       cacheDir: fileConfig.embeddingCacheDir
         ? expandPath(fileConfig.embeddingCacheDir)
         : join(dataDir, "models"),
+      loadTimeoutMs: parseFloatEnv(
+        "ENGRAM_EMBEDDING_LOAD_TIMEOUT_MS",
+        process.env.ENGRAM_EMBEDDING_LOAD_TIMEOUT_MS,
+        fileConfig.embeddingLoadTimeoutMs ?? 60_000,
+      ),
     },
     features: {
       scopes:
@@ -267,6 +307,18 @@ function getFallbackConfig(): Config {
         1.0,
       ),
     },
+    recall: {
+      recencyWeight: parseFloatEnv(
+        "ENGRAM_RECENCY_WEIGHT",
+        process.env.ENGRAM_RECENCY_WEIGHT,
+        0.2,
+      ),
+      recencyHalfLifeDays: parseFloatEnv(
+        "ENGRAM_RECENCY_HALF_LIFE_DAYS",
+        process.env.ENGRAM_RECENCY_HALF_LIFE_DAYS,
+        14,
+      ),
+    },
     http: {
       port: parsePortEnv(
         "ENGRAM_HTTP_PORT",
@@ -278,6 +330,11 @@ function getFallbackConfig(): Config {
     embedding: {
       model: process.env.ENGRAM_EMBEDDING_MODEL || "Xenova/bge-small-en-v1.5",
       cacheDir: join(dataDir, "models"),
+      loadTimeoutMs: parseFloatEnv(
+        "ENGRAM_EMBEDDING_LOAD_TIMEOUT_MS",
+        process.env.ENGRAM_EMBEDDING_LOAD_TIMEOUT_MS,
+        60_000,
+      ),
     },
     features: {
       scopes: process.env.ENGRAM_ENABLE_SCOPES !== "0",

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -312,7 +312,10 @@ function applyMemoryFilters(
   params: Record<string, string | number>,
 ): void {
   if (filters.scope_id) {
-    clauses.push("(scope_id = $scope_id OR scope_id IS NULL)");
+    // Strict scope match. NULL-scoped (legacy/unscoped) memories are NOT
+    // included — they would otherwise leak into every scoped query. Callers
+    // that want unscoped memories should omit scope_id entirely.
+    clauses.push("scope_id = $scope_id");
     params.$scope_id = filters.scope_id;
   }
   if (filters.chat_id) {

--- a/src/embedding.ts
+++ b/src/embedding.ts
@@ -18,6 +18,25 @@ let isInitializing = false;
 let initPromise: Promise<Result<FeatureExtractionPipeline>> | null = null;
 
 /**
+ * Reject if a promise does not settle within `ms`. The underlying promise is
+ * left to settle on its own (we cannot cancel transformers.js mid-load), but
+ * the caller is unblocked so it can fall back instead of hanging forever.
+ */
+function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  message: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() =>
+    clearTimeout(timer),
+  ) as Promise<T>;
+}
+
+/**
  * Get or initialize the embedding pipeline.
  * Lazy-loads the model on first use.
  * Returns Err on model load failure instead of throwing.
@@ -41,13 +60,21 @@ export async function getEmbedder(): Promise<
     try {
       log(`loading embedding model: ${config.embedding.model}`);
       const start = Date.now();
-      const pipe = await pipeline(
+      const loadTimeoutMs = config.embedding.loadTimeoutMs;
+      const loadPromise = pipeline(
         "feature-extraction",
         config.embedding.model,
         {
           dtype: "q8" as const, // Quantized for smaller size
           cache_dir: config.embedding.cacheDir,
         },
+      );
+      // Bound the load so a stalled network fetch can't hang recall/remember
+      // indefinitely. On timeout we fall back to FTS5 keyword search.
+      const pipe = await withTimeout(
+        loadPromise,
+        loadTimeoutMs,
+        `embedding model load exceeded ${loadTimeoutMs}ms`,
       );
       log(`embedding model loaded in ${Date.now() - start}ms`);
       return ok(pipe as FeatureExtractionPipeline);

--- a/src/tools/recall.ts
+++ b/src/tools/recall.ts
@@ -28,6 +28,7 @@ export interface RecallMemory {
   id: string;
   content: string;
   category: string | null;
+  scope_id: string | null;
   strength: number;
   relevance: number;
   created_at: string;
@@ -84,6 +85,11 @@ export async function recall(input: RecallInput): Promise<RecallOutput> {
 
   const queryEmbedding = queryEmbeddingResult.value;
 
+  // Recency-aware ranking config. Among semantically similar memories,
+  // newer ones should win — mirrors how human recall favors recent context.
+  const { recencyWeight, recencyHalfLifeDays } = config.recall;
+  const now = Date.now();
+
   // Compute similarity for all memories with embeddings
   // Apply decay to strength before filtering
   const allDecayed = memoriesWithEmbeddings.map((m) => {
@@ -94,12 +100,27 @@ export async function recall(input: RecallInput): Promise<RecallOutput> {
       m.access_count,
       m.strength,
     );
+
+    // Recency score: exponential decay from creation time.
+    // A memory `recencyHalfLifeDays` old scores 0.5; brand new scores ~1.0.
+    const ageDays = (now - new Date(m.created_at).getTime()) / 86_400_000;
+    const recencyScore = Math.pow(
+      0.5,
+      Math.max(ageDays, 0) / recencyHalfLifeDays,
+    );
+
+    // Blend semantic relevance with recency. recencyWeight=0 reproduces
+    // legacy pure-similarity ranking.
+    const score =
+      similarity * (1 - recencyWeight) + recencyScore * recencyWeight;
+
     return {
       id: m.id,
       content: m.content,
       category: m.category,
+      scope_id: m.scope_id,
       strength: decayedStrength,
-      relevance: similarity,
+      relevance: score,
       created_at: m.created_at,
       access_count: m.access_count,
     };
@@ -178,6 +199,7 @@ function recallFTS5(
     id: m.id,
     content: m.content,
     category: m.category,
+    scope_id: m.scope_id,
     strength: m.decayedStrength,
     relevance: Math.exp(m.rank), // e^rank normalizes BM25
     created_at: m.created_at,
@@ -242,6 +264,7 @@ function recallFallback(
     id: m.id,
     content: m.content,
     category: m.category,
+    scope_id: m.scope_id,
     strength: m.decayedStrength,
     relevance: m.decayedStrength, // Use decayed strength as relevance for fallback
     created_at: m.created_at,

--- a/test/forget.test.ts
+++ b/test/forget.test.ts
@@ -1,4 +1,11 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
 import {
   closeDatabase,
   getMemoryById,
@@ -6,17 +13,21 @@ import {
   initDatabase,
   resetDatabase,
 } from "../src/db";
-import { resetEmbedder } from "../src/embedding";
+import { preloadEmbedder } from "../src/embedding";
 import { forget } from "../src/tools/forget";
 import { remember } from "../src/tools/remember";
 
 describe("forget tool", () => {
   const originalScopes = process.env.ENGRAM_ENABLE_SCOPES;
 
+  // Load the embedding model once for the whole file (see recall.test.ts).
+  beforeAll(async () => {
+    await preloadEmbedder();
+  });
+
   beforeEach(() => {
     process.env.ENGRAM_ENABLE_SCOPES = "0";
     resetDatabase();
-    resetEmbedder();
     initDatabase(":memory:");
   });
 

--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -1,4 +1,11 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
 import {
   closeDatabase,
   getMetricsSummary,
@@ -6,14 +13,18 @@ import {
   logMetric,
   resetDatabase,
 } from "../src/db";
-import { resetEmbedder } from "../src/embedding";
+import { preloadEmbedder } from "../src/embedding";
 import { recall } from "../src/tools/recall";
 import { remember } from "../src/tools/remember";
 
 describe("metrics", () => {
+  // Load the embedding model once for the whole file (see recall.test.ts).
+  beforeAll(async () => {
+    await preloadEmbedder();
+  });
+
   beforeEach(() => {
     resetDatabase();
-    resetEmbedder();
     initDatabase(":memory:");
   });
 

--- a/test/recall.test.ts
+++ b/test/recall.test.ts
@@ -1,4 +1,11 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
 import {
   closeDatabase,
   getDatabase,
@@ -6,7 +13,7 @@ import {
   initDatabase,
   resetDatabase,
 } from "../src/db";
-import { resetEmbedder } from "../src/embedding";
+import { preloadEmbedder } from "../src/embedding";
 import { forget } from "../src/tools/forget";
 import { recall } from "../src/tools/recall";
 import { remember } from "../src/tools/remember";
@@ -22,10 +29,17 @@ function unwrap<T>(
 describe("recall tool", () => {
   const originalScopes = process.env.ENGRAM_ENABLE_SCOPES;
 
+  // Load the embedding model once for the whole file. The embedder is an
+  // immutable singleton; resetting it per-test forced a reload on every test,
+  // which hammered the HuggingFace hub and triggered HTTP 429 rate limiting
+  // in CI. Loading once keeps it warm and makes a single network fetch.
+  beforeAll(async () => {
+    await preloadEmbedder();
+  });
+
   beforeEach(() => {
     process.env.ENGRAM_ENABLE_SCOPES = "0";
     resetDatabase();
-    resetEmbedder();
     initDatabase(":memory:");
   });
 

--- a/test/recall.test.ts
+++ b/test/recall.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   closeDatabase,
+  getDatabase,
   getMemoryById,
   initDatabase,
   resetDatabase,
@@ -152,7 +153,7 @@ describe("recall tool", () => {
     expect(result.memories[0].content).toBe("Project A memory");
   });
 
-  test("scoped recall includes unscoped (NULL scope_id) memories", async () => {
+  test("scoped recall excludes unscoped (NULL scope_id) memories", async () => {
     process.env.ENGRAM_ENABLE_SCOPES = "1";
 
     await remember({ content: "Legacy unscoped memory" });
@@ -162,9 +163,25 @@ describe("recall tool", () => {
     const result = await recall({ query: "memory", scope_id: "takumi" });
 
     const contents = result.memories.map((m) => m.content);
-    expect(contents).toContain("Legacy unscoped memory");
+    // Strict scope filtering: only exact scope matches are returned.
+    // NULL-scoped (legacy/unscoped) memories no longer leak into scoped queries.
     expect(contents).toContain("Scoped memory for agent");
+    expect(contents).not.toContain("Legacy unscoped memory");
     expect(contents).not.toContain("Other agent memory");
+  });
+
+  test("unscoped recall (no scope_id) returns all memories", async () => {
+    process.env.ENGRAM_ENABLE_SCOPES = "1";
+
+    await remember({ content: "Global memory thing" });
+    await remember({ content: "Project memory thing", scope_id: "proj-x" });
+
+    const result = await recall({ query: "memory thing" });
+
+    const contents = result.memories.map((m) => m.content);
+    // Omitting scope_id returns everything (scoped + unscoped).
+    expect(contents).toContain("Global memory thing");
+    expect(contents).toContain("Project memory thing");
   });
 
   // Semantic search behavior tests
@@ -182,8 +199,16 @@ describe("recall tool", () => {
     });
 
     test("returns no results for completely unrelated query when no embeddings match", async () => {
-      await remember({ content: "TypeScript is great" });
-      await remember({ content: "Python is good" });
+      const a = unwrap(await remember({ content: "TypeScript is great" }));
+      const b = unwrap(await remember({ content: "Python is good" }));
+
+      // Backdate so the recency component of the blended score is negligible,
+      // isolating semantic similarity (which is what this test asserts).
+      getDatabase()
+        .prepare(
+          "UPDATE memories SET created_at = datetime('now', '-365 days') WHERE id IN ($a, $b)",
+        )
+        .run({ $a: a.id, $b: b.id });
 
       // Even with semantic search, very unrelated content should score low
       const result = await recall({ query: "cooking recipes for pasta" });
@@ -228,6 +253,30 @@ describe("recall tool", () => {
       expect(result.memories.length).toBe(2);
       // "automobile" should be semantically similar to "car"
       expect(result.memories[0].content).toContain("automobile");
+    });
+
+    test("recency breaks ties between semantically similar memories", async () => {
+      // Two near-identical memories. Without recency weighting they tie on
+      // cosine similarity and ordering is arbitrary. With recency weighting,
+      // the newer one must rank first.
+      const oldMem = unwrap(
+        await remember({ content: "Session index: project status update" }),
+      );
+      const newMem = unwrap(
+        await remember({ content: "Session index: project status update" }),
+      );
+
+      // Backdate the first memory by 60 days (>4 half-lives).
+      getDatabase()
+        .prepare(
+          "UPDATE memories SET created_at = datetime('now', '-60 days') WHERE id = $id",
+        )
+        .run({ $id: oldMem.id });
+
+      const result = await recall({ query: "session index project status" });
+
+      expect(result.memories.length).toBe(2);
+      expect(result.memories[0].id).toBe(newMem.id);
     });
   });
 });

--- a/test/remember.test.ts
+++ b/test/remember.test.ts
@@ -1,22 +1,33 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
 import {
   closeDatabase,
   getMemoryById,
   initDatabase,
   resetDatabase,
 } from "../src/db";
-import { resetEmbedder } from "../src/embedding";
+import { preloadEmbedder } from "../src/embedding";
 import { remember } from "../src/tools/remember";
 
 describe("remember tool", () => {
   const originalScopes = process.env.ENGRAM_ENABLE_SCOPES;
   const originalIdempotency = process.env.ENGRAM_ENABLE_IDEMPOTENCY;
 
+  // Load the embedding model once for the whole file (see recall.test.ts).
+  beforeAll(async () => {
+    await preloadEmbedder();
+  });
+
   beforeEach(() => {
     process.env.ENGRAM_ENABLE_SCOPES = "0";
     process.env.ENGRAM_ENABLE_IDEMPOTENCY = "0";
     resetDatabase();
-    resetEmbedder();
     initDatabase(":memory:");
   });
 


### PR DESCRIPTION
## Problem

Two defects made recall unreliable for the session-index / project-memory use case:

1. **No recency in ranking.** Recall sorted purely by cosine similarity. Among semantically near-identical memories (e.g. dated session indices), the newest never reliably surfaced — an old May memory would win over the latest June one at random.

2. **Scope filtering leaked NULL-scoped rows.** The filter was `(scope_id = ? OR scope_id IS NULL)`, so every legacy unscoped memory (Wilson, SolidWorks, etc.) matched *every* scoped query. Scoping was effectively a no-op once legacy data existed.

## Changes

- **Recency-aware ranking** (`src/tools/recall.ts`): blend a recency score into the semantic ranking — `finalScore = relevance*(1-w) + recencyScore*w`, where `recencyScore` is exponential decay from `created_at`. Configurable `recencyWeight` (default 0.2) and `recencyHalfLifeDays` (default 14). `w=0` reproduces legacy pure-similarity behavior.
- **Strict scope filtering** (`src/db/index.ts`): `scope_id = ?` instead of including NULL. Callers wanting unscoped results omit `scope_id`.
- **Expose `scope_id`** on recall results for transparency/debugging.
- **Embedder load timeout** (`src/embedding.ts`): a stalled model fetch now falls back to FTS5 instead of hanging indefinitely (`embeddingLoadTimeoutMs`, default 60s).

## Tests

- strict-scope inclusion + exclusion + unscoped-returns-all
- recency tie-break between identical-content memories (backdated fixture)
- updated the 'unrelated query scores low' test to backdate fixtures, isolating the semantic component from the new recency blend

All typecheck / lint / format / 150 tests pass.

## Notes

- `relevance` in the output is now the blended score (what consumers already sort by). Raw cosine is no longer separately exposed.
- Behavior for distinct-content queries is essentially unchanged (recency weight is small).