### PR TITLE
feat(recall): expose idempotency_key in results

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -604,6 +604,7 @@ export interface MemoryWithEmbedding {
   chat_id: string | null;
   thread_id: string | null;
   task_id: string | null;
+  idempotency_key: string | null;
   strength: number;
   created_at: string;
   last_accessed: string;
@@ -623,7 +624,7 @@ export function getAllMemoriesWithEmbeddings(
   applyMemoryFilters(filters, clauses, params);
   const whereClause = `WHERE ${clauses.join(" AND ")}`;
   const stmt = database.prepare(
-    `SELECT id, content, category, scope_id, chat_id, thread_id, task_id, strength, created_at, last_accessed, access_count, embedding FROM memories ${whereClause}`,
+    `SELECT id, content, category, scope_id, chat_id, thread_id, task_id, idempotency_key, strength, created_at, last_accessed, access_count, embedding FROM memories ${whereClause}`,
   );
   return stmt.all(params) as MemoryWithEmbedding[];
 }

--- a/src/tools/recall.ts
+++ b/src/tools/recall.ts
@@ -29,6 +29,7 @@ export interface RecallMemory {
   content: string;
   category: string | null;
   scope_id: string | null;
+  idempotency_key: string | null;
   strength: number;
   relevance: number;
   created_at: string;
@@ -119,6 +120,7 @@ export async function recall(input: RecallInput): Promise<RecallOutput> {
       content: m.content,
       category: m.category,
       scope_id: m.scope_id,
+      idempotency_key: m.idempotency_key,
       strength: decayedStrength,
       relevance: score,
       created_at: m.created_at,
@@ -200,6 +202,7 @@ function recallFTS5(
     content: m.content,
     category: m.category,
     scope_id: m.scope_id,
+    idempotency_key: m.idempotency_key,
     strength: m.decayedStrength,
     relevance: Math.exp(m.rank), // e^rank normalizes BM25
     created_at: m.created_at,
@@ -265,6 +268,7 @@ function recallFallback(
     content: m.content,
     category: m.category,
     scope_id: m.scope_id,
+    idempotency_key: m.idempotency_key,
     strength: m.decayedStrength,
     relevance: m.decayedStrength, // Use decayed strength as relevance for fallback
     created_at: m.created_at,

--- a/test/recall.test.ts
+++ b/test/recall.test.ts
@@ -121,6 +121,27 @@ describe("recall tool", () => {
     expect(result.memories[0].created_at).toBeDefined();
     expect(result.memories[0].access_count).toBeGreaterThanOrEqual(1);
     expect(result.memories[0].relevance).toBeGreaterThan(0);
+    // idempotency_key is part of the shape (null when not set) so callers can
+    // deterministically identify a specific memory (e.g. a HEAD pointer).
+    expect("idempotency_key" in result.memories[0]).toBe(true);
+  });
+
+  test("exposes idempotency_key so callers can identify a specific memory", async () => {
+    process.env.ENGRAM_ENABLE_IDEMPOTENCY = "1";
+    await remember({
+      content: "HEAD pointer content",
+      idempotency_key: "proj:fact:session-index",
+    });
+    await remember({ content: "Some other unrelated memory" });
+
+    const result = await recall({ query: "HEAD pointer content" });
+
+    const head = result.memories.find(
+      (m) => m.idempotency_key === "proj:fact:session-index",
+    );
+    expect(head).toBeDefined();
+    expect(head?.content).toBe("HEAD pointer content");
+    delete process.env.ENGRAM_ENABLE_IDEMPOTENCY;
   });
 
   test("fallback mode is false when query is provided", async () => {


### PR DESCRIPTION
## Problem

Recall results omitted `idempotency_key`, so a caller could not deterministically identify a specific memory by its stable key. This breaks the HEAD-pointer pattern: a `/resume` flow that wants the memory keyed `<project>:fact:session-index` had no way to pick it out of many semantically similar session indices — it was forced to guess by content or recency, and guessed wrong (returned a stale dated session instead of the HEAD).

## Change

- Add `idempotency_key` to the semantic-search column projection (`getAllMemoriesWithEmbeddings`).
- Add `idempotency_key` to the `RecallMemory` output type and all three result paths (semantic, FTS5, fallback).
- MCP and HTTP serialize the whole recall result, so the field passes through automatically.

## Tests

- Shape test now asserts `idempotency_key` is present on results.
- New test: a memory stored with a known `idempotency_key` is selectable from recall results by that key.

All typecheck / lint / format / 151 tests pass.